### PR TITLE
CI: run unit tests on push/PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,51 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Unit tests (WODTimerEngine)
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Select an available iPhone simulator
+        id: sim
+        run: |
+          UDID=$(xcrun simctl list devices available --json \
+            | python3 -c "import sys, json; \
+devices = json.load(sys.stdin)['devices']; \
+ids = [d['udid'] for rt, devs in devices.items() if 'iOS' in rt for d in devs if d['name'].startswith('iPhone')]; \
+print(ids[0] if ids else '')")
+          if [ -z "$UDID" ]; then
+            echo "No iOS Simulator available on this runner" >&2
+            exit 1
+          fi
+          echo "Using simulator UDID: $UDID"
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
+      - name: Run unit tests
+        run: |
+          xcodebuild test \
+            -project WODrounds.xcodeproj \
+            -scheme WODrounds \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            -only-testing:WODroundsTests \
+            CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,11 +29,7 @@ jobs:
       - name: Select an available iPhone simulator
         id: sim
         run: |
-          UDID=$(xcrun simctl list devices available --json \
-            | python3 -c "import sys, json; \
-devices = json.load(sys.stdin)['devices']; \
-ids = [d['udid'] for rt, devs in devices.items() if 'iOS' in rt for d in devs if d['name'].startswith('iPhone')]; \
-print(ids[0] if ids else '')")
+          UDID=$(xcrun simctl list devices available --json | python3 -c "import sys, json; d = json.load(sys.stdin)['devices']; ids = [x['udid'] for rt, devs in d.items() if 'iOS' in rt for x in devs if x['name'].startswith('iPhone')]; print(ids[0] if ids else '')")
           if [ -z "$UDID" ]; then
             echo "No iOS Simulator available on this runner" >&2
             exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Show Xcode version
         run: xcodebuild -version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,15 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
+      # Sentry.xcconfig is gitignored (it holds the DSN); the project's base
+      # configuration references it, so provide the placeholder template here.
+      # Sentry no-ops on an empty/placeholder DSN, so tests are unaffected.
+      - name: Provide Sentry config
+        run: |
+          if [ ! -f Sentry.xcconfig ]; then
+            cp Sentry.xcconfig.example Sentry.xcconfig
+          fi
+
       - name: Select an available iPhone simulator
         id: sim
         run: |


### PR DESCRIPTION
Closes #39.

Adds a `Tests` GitHub Actions workflow so the engine unit tests gate merges to `main`.

## Details
- Runs on `macos-latest`, on push to `main` and on PRs targeting `main`.
- **Dynamic simulator selection:** picks the first available iPhone simulator via `simctl` instead of hardcoding a model/OS, so the workflow doesn't break when the runner image's Xcode/simulator set changes.
- Scoped to `-only-testing:WODroundsTests` to keep runs fast and avoid UI-test flakiness; `CODE_SIGNING_ALLOWED=NO` (same as the CodeQL build).
- Follows the existing `concurrency` + `permissions: contents: read` conventions from `codeql.yml`.

Complements #29 (adding new Watch/HealthKit tests) — once those land they'll run here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)