### PR TITLE
Cancel during count-in (#38) + remove dead macOS sound toggle (#37)

### DIFF
--- a/WODrounds/iOSContentView.swift
+++ b/WODrounds/iOSContentView.swift
@@ -367,11 +367,19 @@ private struct iOSContent: View {
                         .font(.system(size: DesignTokens.Typography.Size.display * fontScale, weight: DesignTokens.Typography.Weight.bold, design: .monospaced))
                         .monospacedDigit()
                         .foregroundStyle(DesignTokens.Common.Text.primary(scheme))
+                    SharedCancelButton(action: {
+                        countdownEndTime = nil
+                        Haptics.light()
+                    }, theme: cancelTheme)
+                    .frame(maxWidth: maxContentWidth)
+                    .padding(.top, DesignTokens.Spacing.xl * spacingScale)
+                    .padding(.horizontal, DesignTokens.Spacing.xxxl)
+                    .accessibilityLabel("Cancel countdown")
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(DesignTokens.Common.Background.app(scheme))
                 .transition(.opacity)
-                .accessibilityElement(children: .ignore)
+                .accessibilityElement(children: .contain)
                 .accessibilityLabel("Countdown, \(remaining) seconds")
             }
         }

--- a/WODrounds/macOSContentView.swift
+++ b/WODrounds/macOSContentView.swift
@@ -66,7 +66,6 @@ private struct MacContent: View {
     @State private var flashScreen = false
     @State private var lastHapticRound = 0
     @State private var lastHapticPhase: WODTimerPhase?
-    @AppStorage("soundEnabled") private var soundEnabled: Bool = true
 
     private static let macDoneTheme = DoneViewTheme(
         checkmarkSize: 64,
@@ -241,25 +240,12 @@ private struct MacContent: View {
         .padding(.horizontal, DesignTokens.Spacing.lg)
     }
 
+    // macOS has no audio cues (WorkoutSoundManager is iOS/tvOS only), so no sound toggle is shown.
     private var topRightControls: some View {
         HStack(spacing: DesignTokens.Spacing.sm) {
-            soundToggleButton
             infoButton
         }
         .padding(DesignTokens.Spacing.md)
-    }
-
-    private var soundToggleButton: some View {
-        Button {
-            soundEnabled.toggle()
-        } label: {
-            Image(systemName: soundEnabled ? "speaker.wave.2" : "speaker.slash")
-                .font(.system(size: DesignTokens.Typography.Size.lg, weight: DesignTokens.Typography.Weight.regular))
-                .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
-                .contentTransitionInterpolateCompat()
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(soundEnabled ? "Mute sound" : "Unmute sound")
     }
 
     private var infoButton: some View {
@@ -295,10 +281,14 @@ private struct MacContent: View {
                             .font(.system(size: DesignTokens.Typography.Size.display, weight: DesignTokens.Typography.Weight.bold, design: .monospaced))
                             .monospacedDigit()
                             .foregroundStyle(DesignTokens.Common.Text.primary(scheme))
+                        SharedCancelButton(action: { countdownEndTime = nil }, theme: Self.macCancelTheme)
+                            .padding(.top, DesignTokens.Spacing.xl)
+                            .padding(.horizontal, DesignTokens.Spacing.xxxl)
+                            .accessibilityLabel("Cancel countdown")
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(DesignTokens.Common.Background.app(scheme))
-                    .accessibilityElement(children: .ignore)
+                    .accessibilityElement(children: .contain)
                     .accessibilityLabel("Countdown, \(remaining) seconds")
                 }
             }

--- a/WODrounds/tvOSContentView.swift
+++ b/WODrounds/tvOSContentView.swift
@@ -303,10 +303,14 @@ struct ContentView: View {
                             .font(.system(size: TVOSTypography.display, weight: DesignTokens.Typography.Weight.bold, design: .monospaced))
                             .monospacedDigit()
                             .foregroundStyle(DesignTokens.Common.Text.primary(scheme))
+                        SharedCancelButton(action: { countdownEndTime = nil }, theme: Self.tvOSCancelTheme)
+                            .frame(maxWidth: 600)
+                            .padding(.top, DesignTokens.Spacing.xl)
+                            .accessibilityLabel("Cancel countdown")
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(DesignTokens.Common.Background.app(scheme))
-                    .accessibilityElement(children: .ignore)
+                    .accessibilityElement(children: .contain)
                     .accessibilityLabel("Countdown, \(remaining) seconds")
                 }
             }


### PR DESCRIPTION
Closes #38. Closes #37.

Builds clean on iOS, macOS and tvOS (exit 0, no new warnings).

## #38 — Allow cancelling the 10s "Get ready" count-in
During the count-in `engine.state` is still `.idle`, so the primary button shows "Start" and the run/pause Cancel button is hidden — there was no way to abort. Added a **Cancel** button inside the count-in overlay on all three platforms; it clears `countdownEndTime` and returns to setup. No HealthKit workout has started yet during count-in, so nothing needs discarding. The overlay's accessibility element is now `.contain` (was `.ignore`) so VoiceOver / tvOS focus can reach the button.

- `WODrounds/iOSContentView.swift`, `WODrounds/macOSContentView.swift`, `WODrounds/tvOSContentView.swift`

## #37 — Remove the non-functional macOS sound toggle
`WorkoutSoundManager` is compiled `#if os(iOS) || os(tvOS)`, so macOS never plays audio — yet macOS rendered a speaker/mute toggle that toggled `soundEnabled` to no effect. Removed the toggle button and its now-unused `@AppStorage("soundEnabled")` state on macOS. iOS/tvOS keep their working toggle.

- `WODrounds/macOSContentView.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)