### PR TITLE
CI: fix broken CodeQL build (#43) + Node 24 action bumps (#44)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+
+      # Sentry.xcconfig is gitignored (it holds the DSN); the project's base
+      # configuration references it, so the build (and thus CodeQL analysis)
+      # fails on a clean checkout without it. Provide the placeholder template.
+      - name: Provide Sentry config
+        run: |
+          if [ ! -f Sentry.xcconfig ]; then
+            cp Sentry.xcconfig.example Sentry.xcconfig
+          fi
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,9 +37,20 @@ jobs:
           fi
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: swift
+
+      # Cache the cloned SwiftPM package sources (not build artifacts — caching
+      # DerivedData would skip compilation and starve CodeQL's tracer). Speeds up
+      # dependency resolution while still compiling everything under CodeQL.
+      - name: Cache SwiftPM packages
+        uses: actions/cache@v4
+        with:
+          path: .spm-cache
+          key: spm-${{ runner.os }}-${{ hashFiles('WODrounds.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
 
       - name: Build for CodeQL
         run: |
@@ -47,8 +58,9 @@ jobs:
             -scheme WODrounds \
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \
+            -clonedSourcePackagesDirPath .spm-cache \
             CODE_SIGNING_ALLOWED=NO \
             build
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,9 @@
 name: CodeQL
 
+# CodeQL Swift analysis traces the compiler through a full build (~30 min),
+# so we don't run it on every push to main — only on PRs (pre-merge) and a
+# weekly scheduled scan. This keeps coverage without paying 30 min per push.
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,10 +17,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Closes #43. Closes #44.

## #43 — CodeQL build had been failing on every run
Confirmed: every CodeQL run on `main` had failed for weeks with `Unable to open base configuration reference file '.../Sentry.xcconfig'`. The project's base configuration references the gitignored `Sentry.xcconfig`, so the build — and all security scanning — failed on a clean checkout. **Verified fixed:** a CodeQL run on this branch now completes `success` for the first time. Added a step that copies the placeholder template before the build (same approach as the Tests workflow #41).

## #44 — Move off deprecated Node.js 20
- `codeql.yml`: `actions/checkout@v4` → `@v5`
- `docs.yml`: `actions/checkout@v4` → `@v5`, `actions/setup-python@v5` → `@v6`
- `codeql.yml`: `github/codeql-action/init` + `analyze` `@v3` → `@v4` (these also ran on Node 20, and v3 is deprecated Dec 2026)
- `tests.yml` (in #41): `actions/checkout@v4` → `@v5` on that branch

## Performance / cost
- **SPM source cache:** cache cloned SwiftPM package sources via `-clonedSourcePackagesDirPath` so dependency resolution is faster on repeat runs. Deliberately *not* caching DerivedData, which would skip compilation and starve CodeQL's compiler tracer.
- **Trigger trim:** CodeQL Swift analysis traces the compiler through a full ~30 min build. Dropped the `push` trigger so it runs on PRs (pre-merge) + the weekly schedule only, instead of paying ~30 min on every push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)