### PR TITLE
macOS: fix clipped layout at default window size (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@ All notable user-facing changes to WODrounds. Newest first.
 - **Fixed:** HealthKit workout duration was inflated when a workout ended or was cancelled while paused — an in-progress pause is now excluded from active time (#34).
 - **Fixed:** "X rounds left" voice cues played twice per round in Intervals mode; they now fire once per round (#35).
 - **Changed:** Removed the non-functional sound toggle on macOS (macOS has no audio cues) (#37).
+- **Fixed:** macOS — the mode switch and Start button were clipped at the default window size; the window now opens tall enough to show the full layout (#47).
 - **Internal:** Removed dead code (#36); added unit + UI test coverage; fixed and hardened CI (CodeQL build, Node 24 action upgrades, unit-test workflow) (#39, #43, #44).

--- a/WODrounds/WODroundsApp.swift
+++ b/WODrounds/WODroundsApp.swift
@@ -54,7 +54,9 @@ struct WODroundsApp: App {
             ContentView()
         }
         #if os(macOS)
-        .defaultSize(width: 340, height: 560)
+        // Tall enough for the full idle layout (mode switch + steppers + Start)
+        // so nothing is clipped at the default size. See issue #47.
+        .defaultSize(width: 340, height: 720)
         #endif
     }
 }

--- a/WODrounds/macOSContentView.swift
+++ b/WODrounds/macOSContentView.swift
@@ -20,7 +20,9 @@ struct ContentView: View {
     @Environment(\.colorScheme) private var scheme
 
     private let maxContentWidth: CGFloat = 320
-    private let maxContentHeight: CGFloat = 520
+    // Must accommodate the full idle layout so the mode switch (top) and Start
+    // button (bottom) aren't clipped at the default window size. See issue #47.
+    private let maxContentHeight: CGFloat = 700
 
     var body: some View {
         TimelineView(.periodic(from: Date(), by: 1.0)) { timeline in


### PR DESCRIPTION
Closes #47. Included in the 1.4 release (the Mac build ships now).

## Problem
At the default window size, the macOS idle content was taller than the window, so SwiftUI compressed the spacers and clipped the EMOM/Intervals mode switch (top) and the Start button (bottom) — only the steppers were visible. The Mac app was effectively unusable at first launch.

## Fix
- `WODroundsApp.swift`: `.defaultSize` height 560 → 720
- `macOSContentView.swift`: `maxContentHeight` 520 → 700

## Verification
Rebuilt and launched the macOS app at the new default size — mode switch, help text, info button (no sound toggle), both steppers, and the Start button all render and are usable. (Screenshots captured during QA.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)