### PR TITLE
Sentry: skip under XCTest + tag non-production environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@ All notable user-facing changes to WODrounds. Newest first.
 - **Fixed:** "X rounds left" voice cues played twice per round in Intervals mode; they now fire once per round (#35).
 - **Changed:** Removed the non-functional sound toggle on macOS (macOS has no audio cues) (#37).
 - **Fixed:** macOS — the mode switch and Start button were clipped at the default window size; the window now opens tall enough to show the full layout (#47).
-- **Internal:** Removed dead code (#36); added unit + UI test coverage; fixed and hardened CI (CodeQL build, Node 24 action upgrades, unit-test workflow) (#39, #43, #44).
+- **Internal:** Removed dead code (#36); added unit + UI test coverage; fixed and hardened CI (CodeQL build, Node 24 action upgrades, unit-test workflow) (#39, #43, #44). Sentry no longer reports under XCTest, and debug/simulator events are tagged with their own environment so they don't appear as production.

--- a/WODrounds/WODroundsApp.swift
+++ b/WODrounds/WODroundsApp.swift
@@ -21,7 +21,14 @@ struct WODroundsApp: App {
 
     #if os(iOS)
     private static func initSentry() {
-        let dsn = ProcessInfo.processInfo.environment["SENTRY_DSN"]
+        // Don't report under XCTest/XCUITest — it only pollutes the project with
+        // test-harness noise (e.g. false "App Hang" events from the simulator).
+        let env = ProcessInfo.processInfo.environment
+        if env["XCTestConfigurationFilePath"] != nil || env["XCTestSessionIdentifier"] != nil {
+            return
+        }
+
+        let dsn = env["SENTRY_DSN"]
             ?? (Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String)
         let dsnTrimmed = dsn?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !dsnTrimmed.isEmpty else {
@@ -32,6 +39,15 @@ struct WODroundsApp: App {
         }
         SentrySDK.start { options in
             options.dsn = dsnTrimmed
+            // Tag non-release builds so simulator/debug events don't masquerade as
+            // production. Only real App Store / TestFlight builds report "production".
+            #if targetEnvironment(simulator)
+            options.environment = "simulator"
+            #elseif DEBUG
+            options.environment = "debug"
+            #else
+            options.environment = "production"
+            #endif
             #if DEBUG
             options.debug = true
             options.tracesSampleRate = 1.0


### PR DESCRIPTION
Included in 1.4. iOS-only.

## Why
QA in the simulator sent test-harness noise to the **production** Sentry project: false "App Hang ≥2000 ms" events (stack trace was `XCTestCore` symbolication on the main thread, `device.simulator = True`) plus the debug connectivity ping — all tagged `environment=production`. Sentry confirms **0 issues on real devices**.

## Fix
- Skip `SentrySDK.start` when running under XCTest/XCUITest (`XCTestConfigurationFilePath` / `XCTestSessionIdentifier`).
- Set `options.environment` to `simulator` / `debug` / `production` by build target, so non-release events don't masquerade as production.

No behaviour change for real App Store / TestFlight builds (still `production`, full reporting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)