### PR TITLE
tvOS: fix remote focus trap (unreachable buttons)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,5 @@ All notable user-facing changes to WODrounds. Newest first.
 - **Changed:** Removed the non-functional sound toggle on macOS (macOS has no audio cues) (#37).
 - **Fixed:** macOS — the mode switch and Start button were clipped at the default window size; the window now opens tall enough to show the full layout (#47).
 - **Changed:** macOS — tidier idle layout: the setup controls are a compact, vertically-centred cluster (only the active mode's steppers render, so EMOM no longer leaves an empty gap reserved for Intervals' third stepper), and the About sheet's Done button is inset from the sheet edges.
+- **Fixed:** tvOS — remote focus could get stuck and the buttons became unreachable. The inactive mode's steppers were hidden with opacity but stayed in the focus engine; they're now only rendered for the active mode, so focus navigation works.
 - **Internal:** Removed dead code (#36); added unit + UI test coverage; fixed and hardened CI (CodeQL build, Node 24 action upgrades, unit-test workflow) (#39, #43, #44). Sentry no longer reports under XCTest, and debug/simulator events are tagged with their own environment so they don't appear as production.

--- a/WODrounds/tvOSContentView.swift
+++ b/WODrounds/tvOSContentView.swift
@@ -238,22 +238,20 @@ struct ContentView: View {
     }
 
     private func tvOSIdleSettingsView(state: WODTimerEngineState) -> some View {
-        ZStack(alignment: .top) {
-            VStack(spacing: DesignTokens.Spacing.xl) {
+        // Render only the active mode's steppers. The previous ZStack overlay kept
+        // the inactive mode's steppers in the view at opacity 0 — but opacity /
+        // allowsHitTesting / accessibilityHidden do NOT remove them from the tvOS
+        // focus engine, so the Siri Remote could move focus into invisible buttons
+        // and get stuck. Conditional rendering removes them entirely.
+        VStack(spacing: DesignTokens.Spacing.xl) {
+            if timerMode == .emom {
                 SharedStepperView(value: $rounds, range: roundsRange, label: "Rounds", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
                 SharedStepperView(value: $emomRoundLengthSeconds, range: emomLengthRange, step: 30, displayString: sharedFormatEmomLength(emomRoundLengthSeconds), label: "Round length", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
-            }
-                .opacity(timerMode == .emom ? 1 : 0)
-                .allowsHitTesting(timerMode == .emom)
-                .accessibilityHidden(timerMode != .emom)
-            VStack(spacing: DesignTokens.Spacing.xl) {
+            } else {
                 SharedStepperView(value: $intervalsWork, range: intervalsWorkRange, label: "Work (sec)", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
                 SharedStepperView(value: $intervalsRest, range: intervalsRestRange, label: "Rest (sec)", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
                 SharedStepperView(value: $intervalsRounds, range: intervalsRoundsRange, label: "Rounds", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
             }
-            .opacity(timerMode == .intervals ? 1 : 0)
-            .allowsHitTesting(timerMode == .intervals)
-            .accessibilityHidden(timerMode != .intervals)
         }
         .animation(.easeInOut(duration: 0.25), value: timerMode)
         .padding(.horizontal, DesignTokens.Spacing.xxl)


### PR DESCRIPTION
Reported: the tvOS app was almost unusable — hard to navigate, couldn't reach the buttons.

## Root cause
`tvOSIdleSettingsView` overlaid the EMOM (2 steppers) and Intervals (3 steppers) stacks in a `ZStack`, hiding the inactive one with `opacity(0)` + `allowsHitTesting(false)` + `accessibilityHidden(true)`. **None of those remove a view from the tvOS focus engine** — so the Siri Remote could move focus into the invisible stepper buttons and get stuck, making the visible controls feel unreachable. (Same overlay that caused the macOS layout gap; on tvOS it's a focus bug.)

## Fix
Render only the **active** mode's steppers (conditional `if timerMode == .emom { … } else { … }`), removing the invisible focusable elements entirely. Same approach as the macOS fix (#47-related).

## Verification
Built + launched on the tvOS simulator: EMOM shows 2 steppers (no reserved 3rd), full layout renders. I can't drive the Siri Remote from here, so **please re-test focus navigation on your Apple TV / TestFlight** — the structural cause (invisible focusable buttons) is removed, but real-remote confirmation is the final check.

tvOS-only; stays in build 12 (not yet uploaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)