### PR TITLE
docs: tvOS 17 minimum on marketing site

### DIFF
--- a/docs/SEO_STRATEGY.md
+++ b/docs/SEO_STRATEGY.md
@@ -32,7 +32,7 @@ Adding breadth weakens the wedge. When in doubt: stay narrow.
 | iPad | Live | iPadOS 16+ |
 | Apple Watch | Live (synced + simple standalone) | watchOS 9+ |
 | Mac | Live | macOS 13+ (Ventura) |
-| Apple TV | Live | tvOS 16+ |
+| Apple TV | Live | tvOS 17+ |
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,7 +50,7 @@
     "name": "WODrounds",
     "url": "https://wodrounds.iamjarl.com/",
     "applicationCategory": "HealthApplication",
-    "operatingSystem": "iOS 16, iPadOS 16, watchOS 9, macOS 13, tvOS 16",
+    "operatingSystem": "iOS 16, iPadOS 16, watchOS 9, macOS 13, tvOS 17",
     "description": "Minimal EMOM and interval timer for CrossFit, HIIT and Tabata. Runs on iPhone, iPad, Apple Watch, Mac and Apple TV. No accounts or ads. Optional crash reporting on iOS; see privacy policy on wodrounds.iamjarl.com.",
     "offers": {
       "@type": "Offer",

--- a/docs/support.html
+++ b/docs/support.html
@@ -81,7 +81,7 @@
           <li>iPhone and iPad (iOS / iPadOS 16+)</li>
           <li>Apple Watch (watchOS 9+)</li>
           <li>Mac (macOS 13+ Ventura)</li>
-          <li>Apple TV (tvOS 16+)</li>
+          <li>Apple TV (tvOS 17+)</li>
         </ul>
 
         <p class="page-meta"><em>Last updated: March 2026</em></p>


### PR DESCRIPTION
Keeps the marketing site consistent with the tvOS deployment-target bump (#53): updates the JSON-LD `operatingSystem`, the support page requirements list, and SEO_STRATEGY from tvOS 16 → 17. Docs integrity checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)