### PR TITLE
docs: fix stale 30-second cue claim + App Store text (incl. Spanish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Tabata (e.g. 20/10 × 8) is a manual Intervals preset.
 - **macOSContentView.swift** — macOS UI: compact window (340×560), flash overlay.
 - **tvOSContentView.swift** — tvOS UI: focus-based navigation, `.buttonStyle(.card)`, large typography, sounds.
 - **SharedTimerViews.swift** — Shared UI components (stepper, primary button, done view, etc.).
-- **WorkoutSoundManager.swift** — Sound cues for round transitions, 30-second warning, and completion (iOS + tvOS).
+- **WorkoutSoundManager.swift** — Sound cues: count-in start, halfway and ten-seconds voice cues, a 3-2-1 countdown, rounds-remaining announcements (10/5/2), and randomized completion (iOS + tvOS).
 - **HealthKitWorkout.swift** — Saves completed workouts to Apple Health as HIIT sessions (iOS only).
 - **WODroundsApp.swift** — App entry, `WindowGroup { ContentView() }`.
 

--- a/docs/APP_STORE_CONNECT.md
+++ b/docs/APP_STORE_CONNECT.md
@@ -42,10 +42,26 @@ Interval timer and workout timer for EMOM, CrossFit, and HIIT. No accounts, no s
 • EMOM: Set rounds (1–120) and round length (0:30–9:30). Start, pause, resume, reset.
 • Intervals: Work, rest, rounds. Perfect for Tabata (20/10 × 8) and any interval workout.
 • Apple Watch: Start on iPhone – watch shows same time and round. Or run the timer on the watch only.
+• Audio cues: "Get ready", halfway and ten-seconds voice cues, a 3-2-1 countdown, rounds remaining (10, 5, 2), and randomized completion sounds.
 • Large type, one-handed use, runs in background. Light and dark theme.
 
 The simplest WOD timer: no database, no sharing. Just timer and rounds.
 ```
+
+---
+
+## What's New in This Version (release notes)
+
+Update per release. Current — **1.4**:
+
+```
+• Cancel the countdown before a workout starts — tapped Start by mistake? Just back out.
+• More accurate workout duration in Apple Health: paused time no longer counts as active.
+• Fixed a doubled voice announcement during interval workouts.
+• Small fixes and polish throughout.
+```
+
+Mac variant (drop the Health line; add the layout note): "Cancel the countdown before a workout starts. · Tidier setup screen. · Small fixes and polish." tvOS variant: "Cancel the countdown before a workout starts. · Smoother remote navigation with a calmer focus highlight. · Small fixes and polish."
 
 ---
 
@@ -213,3 +229,54 @@ interval timer,workout timer,EMOM,Tabata,HIIT,CrossFit,gym,Apple TV,remote,home 
 ## Screenshots (Apple TV)
 
 tvOS typically requires screenshots (e.g. 1920 × 1080). Take from Apple TV simulator or device.
+
+---
+
+# Spanish (es-MX) — iOS
+
+Localization: **Spanish (Mexico)** (serves Latin America + most Spanish-speaking storefronts, incl. US Hispanic). Neutral LatAm vocabulary (e.g. "cuenta regresiva", not the peninsular "cuenta atrás"). App name stays **WODrounds**. In-app strings/audio are still English — this localizes the App Store listing only.
+
+## Subtitle (max 30 characters)
+
+```
+Temporizador HIIT y Tabata
+```
+
+## Promotional Text (max 170 characters)
+
+```
+Temporizador de intervalos para EMOM, Tabata y HIIT. Empieza en el iPhone y sigue en el Apple Watch. Sin registro: solo tiempo, rondas y enfoque.
+```
+
+## Description
+
+```
+Temporizador de intervalos y de entrenamiento para EMOM, CrossFit y HIIT. Sin cuentas, sin registro. Solo tiempo, rondas y enfoque.
+
+• EMOM: define las rondas (1–120) y la duración de cada ronda (0:30–9:30). Inicia, pausa, reanuda y reinicia.
+• Intervalos: trabajo, descanso y rondas. Perfecto para Tabata (20/10 × 8) y cualquier entrenamiento por intervalos.
+• Apple Watch: empieza en el iPhone y el reloj muestra el mismo tiempo y ronda. O usa el temporizador solo en el reloj.
+• Señales de audio: "Get ready", avisos de voz a la mitad y a los diez segundos, cuenta 3-2-1, rondas restantes (10, 5, 2) y sonidos de finalización aleatorios.
+• Texto grande, uso con una mano, funciona en segundo plano. Tema claro y oscuro.
+
+El temporizador WOD más simple: sin base de datos, sin compartir. Solo cronómetro y rondas.
+```
+
+## Keywords (max 100 characters)
+
+Single words, comma-separated, no spaces; excludes terms already in the subtitle (Temporizador/HIIT/Tabata).
+
+```
+intervalos,entrenamiento,EMOM,CrossFit,gimnasio,cronómetro,cuenta,regresiva,WOD,rondas,ejercicio
+```
+
+## What's New in This Version (1.4)
+
+```
+• Cancela la cuenta regresiva antes de empezar: ¿pulsaste Iniciar sin querer? Solo retrocede.
+• Duración del entrenamiento más precisa en la app Salud: el tiempo en pausa ya no cuenta como activo.
+• Se corrigió un anuncio de voz duplicado durante los entrenamientos por intervalos.
+• Pequeñas correcciones y mejoras.
+```
+
+(Mac/tvOS Spanish variants: drop the Apple Watch / Health lines as for English. Add Spanish (Spain) / es-ES later only if Spain shows traction.)

--- a/docs/emom-timer.html
+++ b/docs/emom-timer.html
@@ -161,7 +161,7 @@
           <li class="feature">
             <span class="feature-icon" aria-hidden="true">Cues</span>
             <h3>Sound + haptics</h3>
-            <p>Audio cue at each round start. Haptic feedback on round transitions. A 30-second warning so you know time is running out.</p>
+            <p>Audio cue at each round start. Haptic feedback on round transitions. Voice cues at the halfway point and with ten seconds left, plus a 3-2-1 countdown into each round.</p>
           </li>
           <li class="feature">
             <span class="feature-icon" aria-hidden="true">Watch</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -274,7 +274,7 @@
             <p class="section-lead">Two modes, zero bloat. EMOM gives you a round counter with a configurable minute. Intervals give you work, rest and rounds. Both modes support sound cues and a 10-second countdown to get ready.</p>
             <ul class="check-list">
               <li>10-second countdown before every workout</li>
-              <li>Sound cues at 30 seconds remaining</li>
+              <li>Halfway and ten-seconds voice cues, plus a 3-2-1 countdown</li>
               <li>Haptic feedback on round transitions</li>
               <li>Pause, resume or cancel anytime</li>
             </ul>


### PR DESCRIPTION
Documentation tidy-up after the build-12 changes.

## Fixes
- **Stale claim:** the "30-second warning" sound cue was dead code (`play30SecondsRemaining`, removed in build 12) but was still claimed in `README.md`, `docs/index.html` and `docs/emom-timer.html`. Replaced with the real cues (count-in, halfway, ten-seconds, 3-2-1 countdown, rounds remaining, completion). Localized pages didn't carry the claim.
- **`docs/APP_STORE_CONNECT.md` refreshed:** added the corrected audio-cues bullet to the iOS description, a "What's New (1.4)" section (with Mac/tvOS variants), and the new **Spanish (es-MX)** listing (subtitle, promotional text, description, keywords, what's new).

Docs integrity checks pass. Marketing-site edits are English `index.html` / `emom-timer.html` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)