### PR TITLE
Make the one-time price an explicit selling point (#57)

### DIFF
--- a/docs/APP_STORE_CONNECT.md
+++ b/docs/APP_STORE_CONNECT.md
@@ -44,6 +44,7 @@ Interval timer and workout timer for EMOM, CrossFit, and HIIT. No accounts, no s
 • Apple Watch: Start on iPhone – watch shows same time and round. Or run the timer on the watch only.
 • Audio cues: "Get ready", halfway and ten-seconds voice cues, a 3-2-1 countdown, rounds remaining (10, 5, 2), and randomized completion sounds.
 • Large type, one-handed use, runs in background. Light and dark theme.
+• One-time purchase: pay once, own it forever. No subscription, no ads, no in-app purchases.
 
 The simplest WOD timer: no database, no sharing. Just timer and rounds.
 ```
@@ -174,6 +175,7 @@ Interval timer and workout timer for EMOM, CrossFit, and HIIT on Mac. No account
 • EMOM: Set rounds (1–120) and round length (0:30–9:30). Start, pause, resume, reset.
 • Intervals: Work, rest, rounds. Perfect for Tabata (20/10 × 8) and any interval workout.
 • Compact window, large type. Runs in background. Light and dark theme.
+• One-time purchase: pay once, own it forever. No subscription, no ads, no in-app purchases.
 
 The same minimal WOD timer as on iPhone and Apple Watch – no database, no sharing. Just timer and rounds.
 ```
@@ -216,6 +218,7 @@ Interval timer and workout timer for EMOM, CrossFit, and HIIT on Apple TV. No ac
 • EMOM: Set rounds (1–120) and round length (0:30–9:30). Start, pause, resume, reset with the remote.
 • Intervals: Work, rest, rounds. Perfect for Tabata (20/10 × 8) and any interval workout.
 • Large type for the living room. Focus-friendly UI. Light and dark theme.
+• One-time purchase: pay once, own it forever. No subscription, no ads, no in-app purchases.
 
 The same minimal WOD timer as on iPhone, Watch, and Mac – no database, no sharing. Just timer and rounds.
 ```
@@ -258,6 +261,7 @@ Temporizador de intervalos y de entrenamiento para EMOM, CrossFit y HIIT. Sin cu
 • Apple Watch: empieza en el iPhone y el reloj muestra el mismo tiempo y ronda. O usa el temporizador solo en el reloj.
 • Señales de audio: "Get ready", avisos de voz a la mitad y a los diez segundos, cuenta 3-2-1, rondas restantes (10, 5, 2) y sonidos de finalización aleatorios.
 • Texto grande, uso con una mano, funciona en segundo plano. Tema claro y oscuro.
+• Compra única: paga una vez y es tuyo para siempre. Sin suscripción, sin anuncios, sin compras dentro de la app.
 
 El temporizador WOD más simple: sin base de datos, sin compartir. Solo cronómetro y rondas.
 ```

--- a/docs/about.html
+++ b/docs/about.html
@@ -127,7 +127,7 @@
         <p>If you want to verify any of this, the source is open at <a href="https://github.com/JarlLyng/WODrounds" rel="external">github.com/JarlLyng/WODrounds</a>.</p>
 
         <h2>What I do and don't promise</h2>
-        <p><strong>I promise:</strong> WODrounds will stay free, ad-free, and subscription-free forever. The features will stay narrow. Updates will respect your time — no notification spam, no "what's new" dialogs in the way of starting a workout.</p>
+        <p><strong>I promise:</strong> WODrounds is a one-time purchase — pay once and own it forever. No ads, no subscription, no in-app purchases, no upsells. The features will stay narrow. Updates will respect your time — no notification spam, no "what's new" dialogs in the way of starting a workout.</p>
         <p><strong>I don't promise:</strong> Android support, web version, AMRAP/For Time modes, workout libraries, or social features. If those matter to you, <a href="best-crossfit-timer-apps.html">other apps</a> handle them well.</p>
 
         <h2>How to reach me</h2>

--- a/docs/best-crossfit-timer-apps.html
+++ b/docs/best-crossfit-timer-apps.html
@@ -236,12 +236,19 @@
                 <td style="padding:0.5rem">&#10003;</td>
                 <td style="padding:0.5rem">&#10003;</td>
               </tr>
-              <tr>
+              <tr style="border-bottom:1px solid var(--border)">
                 <td style="padding:0.5rem 1rem">Apple Health</td>
                 <td style="padding:0.5rem">—</td>
                 <td style="padding:0.5rem">—</td>
                 <td style="padding:0.5rem">—</td>
                 <td style="padding:0.5rem">&#10003;</td>
+              </tr>
+              <tr>
+                <td style="padding:0.5rem 1rem">Pricing</td>
+                <td style="padding:0.5rem">Freemium</td>
+                <td style="padding:0.5rem">Subscription</td>
+                <td style="padding:0.5rem">Free</td>
+                <td style="padding:0.5rem">Pay once</td>
               </tr>
             </tbody>
           </table>

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
     "description": "Minimal EMOM and interval timer for CrossFit, HIIT and Tabata. Runs on iPhone, iPad, Apple Watch, Mac and Apple TV. No accounts or ads. Optional crash reporting on iOS; see privacy policy on wodrounds.iamjarl.com.",
     "offers": {
       "@type": "Offer",
-      "price": "0",
+      "price": "2.99",
       "priceCurrency": "USD"
     },
     "screenshot": [
@@ -63,7 +63,7 @@
       "https://wodrounds.iamjarl.com/images/appletv.png"
     ],
     "featureList": "EMOM timer, Interval timer, Tabata presets, iPhone to Watch sync, Apple Health integration, Apple TV support, Mac support, Dark mode, No accounts required",
-    "softwareVersion": "1.3",
+    "softwareVersion": "1.4",
     "author": {
       "@type": "Person",
       "name": "Jarl Lyng",
@@ -118,10 +118,10 @@
       },
       {
         "@type": "Question",
-        "name": "Is there a subscription or in-app purchase?",
+        "name": "How much does WODrounds cost? Is there a subscription?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "WODrounds has no subscription and no in-app purchases. All features are included."
+          "text": "WODrounds is a one-time purchase — pay once and own it forever. No subscription, no in-app purchases, no ads. All features are included. The price is US$2.99 (it varies by region and currency)."
         }
       },
       {
@@ -294,7 +294,7 @@
         <ul class="principles-list">
           <li>No sign-in or accounts required</li>
           <li>No ads or in-app usage analytics; optional crash reports on iOS (<a href="privacy.html">privacy</a>); this site uses Umami for aggregate visits only</li>
-          <li>No subscription required</li>
+          <li>Pay once, own it forever — no subscription, no recurring fees</li>
           <li>No cloud database. Everything stays on your device</li>
           <li>Optional Apple Health write-only on iOS</li>
         </ul>
@@ -327,8 +327,8 @@
             <dd>On iPhone, completed workouts are saved to Apple Health as HIIT sessions if you grant permission. This is optional and write-only. No workout data is sent to any server.</dd>
           </div>
           <div class="faq-item">
-            <dt>Is there a subscription or in-app purchase?</dt>
-            <dd>WODrounds has no subscription and no in-app purchases. All features are included.</dd>
+            <dt>How much does WODrounds cost? Is there a subscription?</dt>
+            <dd>WODrounds is a one-time purchase — pay once and own it forever. No subscription, no in-app purchases, no ads. All features are included. The price is US$2.99 (it varies by region and currency).</dd>
           </div>
           <div class="faq-item">
             <dt>Does WODrounds or this website track me?</dt>


### PR DESCRIPTION
Closes #57.

## Context

The marketing site claimed WODrounds was **free** in several places — but it's a paid **one-time purchase** ($2.99, confirmed live via the iTunes lookup API). So this is partly a correctness fix and partly the positioning the issue asks for.

## Changes

**Correctness**
- `index.html` JSON-LD `Offer.price` `0` → `2.99` — structured data now matches reality (price-0 schema on a paid app is wrong and can hurt rich results).
- `index.html` stale `softwareVersion` `1.3` → `1.4`.
- `about.html` — the "WODrounds will stay **free** … forever" promise was factually wrong; rewritten as a one-time-purchase / no-subscription / no-ads / no-IAP promise.

**Positioning (hybrid: "pay once" as the message; concrete price in one place)**
- `index.html` — pricing FAQ now answers "How much does WODrounds cost?" with the one-time model **and** the concrete US$2.99 (the one explicit-price spot); principles list says "pay once, own it forever".
- `best-crossfit-timer-apps.html` — new **Pricing** row in the comparison table (WODrounds = "Pay once"), mirroring how the page already characterizes each competitor.
- `APP_STORE_CONNECT.md` — one-time-purchase line added to the iOS, Mac, tvOS, and Spanish (es-MX) descriptions.

Sub-page hero-leads (emom/interval/tabata/watch) were left alone — their "no subscription" is true and out of scope.

## Verification
- `scripts/validate_docs.py` passes (image refs, App Store URLs, JSON-LD validity, sitemap, canonicals).
- Rendered output checked in a local preview: FAQ, principles line, JSON-LD Offer/version, and the comparison Pricing row all render as intended.

## Note for follow-up (not in this PR)
The live **App Store description** and the in-app About copy aren't in this repo — copy the updated `APP_STORE_CONNECT.md` text into App Store Connect (Promotional Text can carry "pay once" too, and updates without a new build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)