### PR TITLE
ci: add least-privilege permissions to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,10 @@ on:
       - 'scripts/validate_docs.py'
       - '.github/workflows/docs.yml'
 
+# Least privilege: this workflow only reads the repo to validate docs.
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes the open CodeQL alert **"Workflow does not contain permissions"** (Medium) on `.github/workflows/docs.yml`.

The workflow had no `permissions:` block, so its `GITHUB_TOKEN` inherited the repository-default scope. The job only checks out the repo and runs `validate_docs.py`, so it's scoped to:

```yaml
permissions:
  contents: read
```

`codeql.yml` and `tests.yml` already declare explicit permissions, so this brings docs.yml in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)