### PR TITLE
Add target audience profile

### DIFF
--- a/targetaudience.md
+++ b/targetaudience.md
@@ -1,0 +1,183 @@
+# WODrounds Target Audience
+
+A working profile of who WODrounds is for, grounded in external market data and our
+own early sales. Use it as a decision filter: for any feature, keyword, screenshot,
+or marketing post, ask "does this serve the core user below?" If not, it is probably
+scope creep.
+
+This is a living document. Update it as real usage and sales data accumulate.
+
+---
+
+## TL;DR
+
+> **The core WODrounds user is a 25 to 44 year old functional-fitness athlete who
+> trains CrossFit, HIIT or Tabata, lives inside the Apple ecosystem (iPhone plus
+> Apple Watch), earns above average, is tired of subscriptions and ad-laden apps,
+> and wants one reliable timer that just works and asks nothing of them.**
+
+They do not want a workout social network, a coach, or a tracker. They want a tool.
+
+---
+
+## Market context (why this audience is worth it)
+
+- **CrossFit / functional fitness is a large, affluent niche.** The core age group is
+  25 to 34 (about 40% of athletes) and 35 to 44 (about 20%). Roughly 40 to 45% are
+  women, and the share is rising. Reported average income skews high (often cited
+  around six figures) and the group is highly educated.
+- **HIIT is the most-searched workout category in apps**, and the broader HIIT market
+  is large and growing fast. This is mainstream demand, not a fringe interest.
+- **Apple Watch is the dominant fitness wearable**, and roughly 80% of Apple Watch
+  owners also use an iPhone, which is exactly our platform. Smartwatch and fitness-app
+  adoption correlates strongly with higher income (people earning $75k+ are far more
+  likely to use them than lower-income groups).
+- **The monetization gap we exploit:** about 80% of health and fitness app revenue
+  comes from subscriptions. Our buyer is increasingly subscription-fatigued. A
+  one-time $2.99 purchase is a deliberate counter-position to that crowd.
+
+Takeaway: the audience is affluent, Apple-centric, search-driven, and underserved by
+the subscription-default market. That is a good wedge for a focused paid utility.
+
+---
+
+## Who they are (demographics)
+
+- **Age:** 25 to 44 core, with a meaningful tail into 18 to 24 (younger athletes) and
+  45+ (masters athletes, who are a real and loyal CrossFit segment).
+- **Gender:** roughly balanced, with women a large and growing share. Copy and
+  screenshots should never read as male-only.
+- **Income and education:** above-average income, often college educated. Price is not
+  the obstacle. Trust, friction, and respect for their time are.
+- **Devices:** iPhone plus Apple Watch is the defining combination. Many also have a
+  Mac, and some have an Apple TV they use as a gym or garage clock. Strictly Apple.
+- **Geography (from our early sales):** the United States is the largest market, with
+  strong showings across Northern and Western Europe (Denmark as the home base,
+  plus Germany, France, Belgium, Spain) and pockets in APAC (Singapore). English plus
+  Nordic, DACH, and Spanish-speaking markets are where traction already exists.
+
+---
+
+## Primary personas
+
+### 1. The box CrossFitter (primary)
+Trains at a CrossFit box or follows CrossFit-style programming. Runs EMOMs and
+intervals constantly. Owns an Apple Watch and wants the timer on the wrist, glanceable
+mid-workout, with a haptic on every round so they do not have to look. Values that it
+starts on the iPhone and the Watch just follows. Will pay a few dollars without
+thinking if it removes friction.
+
+**Needs:** reliable round timing that survives the phone locking or pocketing,
+wrist haptics, fast setup, no account.
+
+### 2. The home / garage HIIT trainer (primary)
+Trains at home or in a garage gym. Uses Tabata and interval formats. Likes putting the
+timer on the big screen via Apple TV, or on a Mac on the bench. Cares about a clean,
+large, readable display from across the room.
+
+**Needs:** big readable timer on Mac and Apple TV, simple interval setup, works without
+fiddling.
+
+### 3. The Apple-ecosystem minimalist (cross-cutting)
+May or may not be hardcore CrossFit, but is the kind of person who seeks out native,
+private, no-subscription Apple apps on principle. Reads Apple blogs, cares about
+privacy, dislikes ads and accounts. Often the person who recommends apps to others.
+
+**Needs:** native Apple feel, privacy, pay-once, no bloat. This persona is the bridge
+to the wider IAMJARL portfolio (see below).
+
+### Secondary: the coach / trainer
+Runs class or small-group timing on an Apple TV or iPad. Not the primary target, but a
+high-visibility user: their athletes see the app on the screen every session.
+
+---
+
+## What they value (psychographics)
+
+In rough priority order:
+
+1. **Reliability.** The timer must be correct, especially when backgrounded. This is
+   non-negotiable mid-workout. Our Date-based engine is built for exactly this.
+2. **Low friction.** Open, set, start. No login, no onboarding, no nags.
+3. **Glanceable clarity.** Large type, clear round and phase, readable at a sweaty
+   glance or from across a room.
+4. **Privacy and no ads.** No tracking, no account, no data harvesting.
+5. **Fair, honest pricing.** Pay once, own it. No subscription, no upsell.
+6. **Native Apple quality.** Feels like it belongs on the platform, across all their
+   devices.
+
+---
+
+## Who WODrounds is NOT for (anti-personas)
+
+Being explicit here protects scope.
+
+- **AMRAP / For Time first athletes (today).** Some functional-fitness athletes need
+  AMRAP and For Time as core modes. We do not have them yet. For Time (issue #15) would
+  open this segment; until then they are not our user.
+- **Android users.** Out of scope by design.
+- **Workout-tracking and social seekers.** People who want logging, history, programming,
+  leaderboards, or a feed. That is a different product.
+- **Free-only users.** People who will never pay even a few dollars. The $2.99 price is
+  a deliberate filter, not a bug.
+- **Multi-stage / complex interval programmers.** Power users who want chained,
+  differing work/rest blocks (issue #16) are a maybe-later segment, not the core.
+
+---
+
+## Implications
+
+### Product
+- The biggest audience-expanding feature is **For Time mode (#15)**: it converts the
+  large "AMRAP/For Time" slice of functional-fitness athletes from anti-persona to
+  addressable. This is the highest-leverage feature for growth.
+- Keep resisting tracking, accounts, and social. They would dilute the wedge.
+- Protect Apple Watch and Apple TV experiences: they are differentiators competitors
+  often lack.
+
+### ASO and SEO (our #1 channel)
+- Lead with high-intent terms our user actually searches: interval timer, EMOM, Tabata,
+  HIIT, CrossFit, workout timer, Apple Watch timer, home workout / gym timer.
+- The content site should keep targeting specific intent queries (per-format and
+  per-platform pages), which is how this affluent, search-driven audience discovers us.
+
+### Localization
+- Sales already validate **US English, Nordic (DA/SV/NO), DACH (DE), French, and
+  Spanish** markets. Prioritize ASO keywords and listings in those, in that rough order.
+
+### Marketing channels
+- **Reddit:** r/crossfit, r/homegym, r/AppleWatch are direct lines to personas 1 to 3.
+- **Apple-focused media and blogs:** reach the ecosystem minimalist (persona 3).
+- **Fitness media:** reach the box and home athletes (personas 1 and 2).
+- Pay-once is a story these channels find interesting in a subscription-saturated market.
+
+### Pricing
+- Pay-once is on-strategy for an affluent but subscription-fatigued buyer. The barrier
+  is never the few dollars; it is trust and friction, both of which pay-once reduces.
+
+---
+
+## Portfolio angle (selling many apps)
+
+The through-line buyer across IAMJARL is not "CrossFitters". It is **the discerning,
+privacy-conscious, subscription-fatigued Apple user who happily pays once for a focused,
+native tool that respects them.** WODrounds reaches that person through fitness;
+other apps reach the same person through other single problems.
+
+Implication: brand consistency matters. Every IAMJARL app should reinforce the same
+promise (native, private, pay-once, minimal, no accounts), so that a user who trusts one
+is primed to buy the next. The audience compounds across the portfolio.
+
+---
+
+## Sources
+
+External benchmarks (audience is an external market; figures are directional, not
+WODrounds-specific):
+
+- CrossFit demographics and income: [market.us](https://media.market.us/crossfit-statistics/), [totalshape.com](https://totalshape.com/fitness/crossfit-statistics/), [CrossFitDataLab](https://crossfitdatalab.com/articles/crossfit-open-participation-trends-2019-2026)
+- HIIT market and app demand: [globalgrowthinsights.com](https://www.globalgrowthinsights.com/market-reports/fitness-hiit-high-intensity-interval-training-market-117673), [businessofapps.com](https://www.businessofapps.com/data/health-fitness-app-report/)
+- Apple Watch ownership, income correlation, subscription share of revenue: [businessofapps.com](https://www.businessofapps.com/data/health-fitness-app-report/), [coolest-gadgets.com](https://coolest-gadgets.com/apple-watches-statistics/), [Statista](https://www.statista.com/chart/25982/smartwatch-market-by-brand-us/)
+
+Internal: early App Store sales by country (US and Northern/Western Europe leading),
+pulled via `scripts/asc_downloads.py`.


### PR DESCRIPTION
Adds `targetaudience.md` at the repo root: a working profile of who WODrounds is for, to use as a decision filter for features, ASO, and marketing.

Grounded in external market data (CrossFit and HIIT demographics, Apple Watch ownership and income correlation, the subscription-heavy fitness-app market) and our own early sales by country. Includes:

- A one-line core-user definition and market context
- Three primary personas plus a coach segment, and explicit anti-personas
- Psychographics (what they value) and implications for product, ASO/SEO, localization, channels, and pricing
- A portfolio angle tying the WODrounds audience to the wider IAMJARL buyer

Lives at the repo root (not `docs/`), so it is not published on the marketing site. No private figures (e.g. revenue) included, so it is safe for a public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)