### PR TITLE
chore: adopt IAMJARL project standards (templates + CLAUDE.md)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+# Copy to <repo>/.github/ISSUE_TEMPLATE/bug_report.yml and replace WODrounds / JarlLyng/WODrounds / wodrounds.iamjarl.com.
+name: Bug report
+description: Something in the WODrounds app or marketing site is broken or behaves unexpectedly.
+title: '[Bug] '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The more concrete the details, the faster it can be fixed.
+        For security vulnerabilities, **do not file a public issue** — see [SECURITY.md](https://github.com/JarlLyng/WODrounds/blob/main/SECURITY.md) for the private reporting channel.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: A one-line description of what's wrong.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did this happen?
+      options:
+        - App
+        - Marketing website (wodrounds.iamjarl.com)
+        - Both
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App version
+      description: From the App Store listing or in-app About screen. Leave blank if the bug is on the marketing site.
+
+  - type: input
+    id: os_version
+    attributes:
+      label: OS version
+      description: e.g. iOS 26.2 / macOS 15.
+
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: iPhone / iPad / Mac model.
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps needed to see the bug. A numbered list is ideal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: media
+    attributes:
+      label: Screenshots or screen recording (optional)
+      description: Drag and drop images / videos here. Crops and short clips help a lot for visual bugs.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submit checks
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true
+        - label: This is a public bug report (security issues go to SECURITY.md)
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,3 @@
-# Copy to <repo>/.github/ISSUE_TEMPLATE/bug_report.yml and replace WODrounds / JarlLyng/WODrounds / wodrounds.iamjarl.com.
 name: Bug report
 description: Something in the WODrounds app or marketing site is broken or behaves unexpectedly.
 title: '[Bug] '
@@ -8,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to report a bug. The more concrete the details, the faster it can be fixed.
-        For security vulnerabilities, **do not file a public issue** — see [SECURITY.md](https://github.com/JarlLyng/WODrounds/blob/main/SECURITY.md) for the private reporting channel.
+        For security vulnerabilities, **do not file a public issue**. See [SECURITY.md](https://github.com/JarlLyng/WODrounds/blob/main/SECURITY.md) for the private reporting channel.
 
   - type: input
     id: summary

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Copy to <repo>/.github/ISSUE_TEMPLATE/config.yml and replace WODrounds / JarlLyng/WODrounds / wodrounds.iamjarl.com.
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Support / general help
+    url: https://wodrounds.iamjarl.com/support
+    about: For general questions or anything that isn't a bug, feature, or marketing idea.
+  - name: 🔒 Security vulnerability
+    url: https://github.com/JarlLyng/WODrounds/security/policy
+    about: Please report security issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,3 @@
-# Copy to <repo>/.github/ISSUE_TEMPLATE/config.yml and replace WODrounds / JarlLyng/WODrounds / wodrounds.iamjarl.com.
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Support / general help

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+# Copy to <repo>/.github/ISSUE_TEMPLATE/feature_request.yml and replace WODrounds / JarlLyng/WODrounds.
+name: Feature request
+description: Suggest a new feature or improvement for WODrounds.
+title: '[Feature] '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Every IAMJARL app is deliberately focused, so the clearer the problem you're trying to solve, the easier it is to evaluate. "Not right now" is a normal answer — it's not a judgement of the idea.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the situation or pain point. Skip mentioning a solution here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Your proposed solution (optional)
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered (optional)
+      description: Other approaches, including "do nothing" or current workarounds.
+
+  - type: checkboxes
+    id: alignment
+    attributes:
+      label: Alignment checks
+      description: These keep requests inside the IAMJARL product DNA (native, pay-once, private, focused).
+      options:
+        - label: This does not require an account, cloud sync, or sending data off-device
+          required: true
+        - label: This does not involve subscriptions, in-app purchases, or ad revenue
+          required: true
+        - label: I searched existing issues and didn't find a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,3 @@
-# Copy to <repo>/.github/ISSUE_TEMPLATE/feature_request.yml and replace WODrounds / JarlLyng/WODrounds.
 name: Feature request
 description: Suggest a new feature or improvement for WODrounds.
 title: '[Feature] '
@@ -7,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the suggestion. Every IAMJARL app is deliberately focused, so the clearer the problem you're trying to solve, the easier it is to evaluate. "Not right now" is a normal answer — it's not a judgement of the idea.
+        Thanks for the suggestion. Every IAMJARL app is deliberately focused, so the clearer the problem you're trying to solve, the easier it is to evaluate. "Not right now" is a normal answer; it's not a judgement of the idea.
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/marketing_idea.yml
+++ b/.github/ISSUE_TEMPLATE/marketing_idea.yml
@@ -1,0 +1,45 @@
+# Copy to <repo>/.github/ISSUE_TEMPLATE/marketing_idea.yml and replace WODrounds / JarlLyng/WODrounds.
+# NOTE: this is for PUBLIC-SAFE marketing tasks only. Competitive-sensitive strategy
+# (positioning, pricing reasoning, channel edge, competitor analysis) goes in the PRIVATE
+# iamjarl-strategy hub instead — never in a public issue.
+name: Marketing idea / task
+description: A public-safe marketing idea or task (content, post, screenshot, outreach).
+title: '[Marketing] '
+labels: ['marketing']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For **public-safe** marketing work only — a blog post, a community thread, a screenshot to redo, an ASO copy tweak.
+        **Anything competitive-sensitive** (positioning, pricing reasoning, channel plans that reveal an edge, competitor analysis) does **not** belong in a public issue — put it in the private [iamjarl-strategy](https://github.com/JarlLyng/iamjarl-strategy) hub instead.
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: The idea / task
+      description: What's the marketing move, and what's the goal?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: channel
+    attributes:
+      label: Channel
+      options:
+        - App Store / ASO
+        - SEO / content
+        - Reddit / community
+        - Social
+        - Newsletter / outreach
+        - Website / landing page
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Public-safe check
+      options:
+        - label: This contains nothing a competitor reading it could use against us (else it goes in the private strategy hub)
+          required: true

--- a/.github/ISSUE_TEMPLATE/marketing_idea.yml
+++ b/.github/ISSUE_TEMPLATE/marketing_idea.yml
@@ -1,7 +1,3 @@
-# Copy to <repo>/.github/ISSUE_TEMPLATE/marketing_idea.yml and replace WODrounds / JarlLyng/WODrounds.
-# NOTE: this is for PUBLIC-SAFE marketing tasks only. Competitive-sensitive strategy
-# (positioning, pricing reasoning, channel edge, competitor analysis) goes in the PRIVATE
-# iamjarl-strategy hub instead — never in a public issue.
 name: Marketing idea / task
 description: A public-safe marketing idea or task (content, post, screenshot, outreach).
 title: '[Marketing] '
@@ -10,8 +6,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        For **public-safe** marketing work only — a blog post, a community thread, a screenshot to redo, an ASO copy tweak.
-        **Anything competitive-sensitive** (positioning, pricing reasoning, channel plans that reveal an edge, competitor analysis) does **not** belong in a public issue — put it in the private [iamjarl-strategy](https://github.com/JarlLyng/iamjarl-strategy) hub instead.
+        For **public-safe** marketing work only: a blog post, a community thread, a screenshot to redo, an ASO copy tweak.
+        **Anything competitive-sensitive** (positioning, pricing reasoning, channel plans that reveal an edge, competitor analysis) does **not** belong in a public issue; put it in the private strategy hub instead.
 
   - type: textarea
     id: idea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Copy to <repo>/.github/pull_request_template.md -->
+## What & why
+<!-- What does this change, and what problem does it solve? Link the issue: Closes #123 -->
+
+## How to test
+<!-- Steps for a reviewer to verify the change. -->
+
+## Checklist
+- [ ] Builds and runs; existing tests pass
+- [ ] No hardcoded colors/spacing/type — uses `iamjarl-design` tokens (if applicable)
+- [ ] No new tracking, accounts, subscriptions, or off-device data (product DNA)
+- [ ] Docs / CHANGELOG updated if behavior changed
+- [ ] No competitive-sensitive strategy added to this public repo (that goes in the private hub)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-<!-- Copy to <repo>/.github/pull_request_template.md -->
 ## What & why
 <!-- What does this change, and what problem does it solve? Link the issue: Closes #123 -->
 
@@ -7,7 +6,7 @@
 
 ## Checklist
 - [ ] Builds and runs; existing tests pass
-- [ ] No hardcoded colors/spacing/type — uses `iamjarl-design` tokens (if applicable)
+- [ ] No hardcoded colors/spacing/type; uses `iamjarl-design` tokens (if applicable)
 - [ ] No new tracking, accounts, subscriptions, or off-device data (product DNA)
 - [ ] Docs / CHANGELOG updated if behavior changed
 - [ ] No competitive-sensitive strategy added to this public repo (that goes in the private hub)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md — WODrounds
+
+Quick-start context for developers and AI assistants. Detailed specs in `docs/`.
+
+## What is WODrounds?
+
+A minimal SwiftUI interval timer for CrossFit, EMOM, Tabata and intervals across iPhone, iPad, Apple Watch, Mac and Apple TV. A single-purpose tool — **not** social, **not** workout tracking. No accounts, no ads, no subscription. Start a workout on iPhone and follow it on Watch (one workout, one synced state).
+
+- **Developer:** Jarl Lyng / [IAMJARL](https://iamjarl.com)
+- **Website:** [wodrounds.iamjarl.com](https://wodrounds.iamjarl.com)
+- **App Store:** [apps.apple.com/app/wodrounds/id6759229877](https://apps.apple.com/app/wodrounds/id6759229877)
+- **License:** [MIT](LICENSE) — open source.
+- **Price:** $2.99 USD one-time (no in-app purchases, no subscription, no ads)
+- **Platforms:** iPhone, iPad, Apple Watch, Mac, Apple TV (SwiftUI; one target, multiple destinations + an embedded Watch target)
+
+## Strategy lives in the private hub
+
+Target audience, positioning, pricing reasoning, SEO/ASO playbooks, and competitor analysis are **not** in this public repo — they're in the private [iamjarl-strategy](https://github.com/JarlLyng/iamjarl-strategy) hub (folder `WODrounds/`). Before doing any audience/positioning/pricing/marketing-planning work, read that repo's `CONVENTIONS.md` and write results there, not here.
+
+## App features (be precise — do not invent features that don't exist)
+
+- **EMOM** — set rounds (1–120) and a custom round length (0:30–9:30, 30s steps); round counter + per-round countdown.
+- **Intervals** — work / rest / rounds, each adjustable; phase display (Work / Rest). Total = `rounds × work + (rounds − 1) × rest` (no rest after last work).
+- **Tabata** — a manual Intervals preset (e.g. 20/10 × 8), not a separate mode.
+- Start / Pause / Resume / Reset / Cancel; Done screen on completion.
+- **iPhone → Watch sync** via WatchConnectivity (start on iPhone, follow on Watch).
+- **Date-based timing** — reliable when backgrounded; deterministic engine (`Shared/WODTimerEngine.swift`), no UI/sound in the engine.
+- Sound cues (count-in, halfway, 10s, 3-2-1, rounds-remaining), haptics (iOS), HealthKit save as HIIT (iOS only).
+
+### Features that do NOT exist (common hallucination targets)
+- No workout *tracking* / history / logbook — it's a timer, not a tracker.
+- No social, sharing, or accounts.
+- No cloud sync or internet dependency.
+
+## Requirements & build
+- Open `WODrounds.xcodeproj`; scheme **WODrounds** (iOS) or **WODrounds Watch** (watchOS).
+- Tests: `WODroundsTests` uses Swift Testing (**Product → Test** / ⌘U).
+- Docs: run `python3 scripts/validate_docs.py` before committing docs changes (also enforced by `.github/workflows/docs.yml`).
+
+## Conventions
+- Uses `iamjarl-design` tokens via SPM — `DesignTokens.swift` re-exports the package and adds app-specific font sizes; no hardcoded colors.
+- Privacy-first: no tracking; HealthKit writes stay on-device.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,35 @@
-# CLAUDE.md — WODrounds
+# CLAUDE.md: WODrounds
 
 Quick-start context for developers and AI assistants. Detailed specs in `docs/`.
 
 ## What is WODrounds?
 
-A minimal SwiftUI interval timer for CrossFit, EMOM, Tabata and intervals across iPhone, iPad, Apple Watch, Mac and Apple TV. A single-purpose tool — **not** social, **not** workout tracking. No accounts, no ads, no subscription. Start a workout on iPhone and follow it on Watch (one workout, one synced state).
+A minimal SwiftUI interval timer for CrossFit, EMOM, Tabata and intervals across iPhone, iPad, Apple Watch, Mac and Apple TV. A single-purpose tool: **not** social, **not** workout tracking. No accounts, no ads, no subscription. Start a workout on iPhone and follow it on Watch (one workout, one synced state).
 
 - **Developer:** Jarl Lyng / [IAMJARL](https://iamjarl.com)
 - **Website:** [wodrounds.iamjarl.com](https://wodrounds.iamjarl.com)
 - **App Store:** [apps.apple.com/app/wodrounds/id6759229877](https://apps.apple.com/app/wodrounds/id6759229877)
-- **License:** [MIT](LICENSE) — open source.
+- **License:** [MIT](LICENSE), open source.
 - **Price:** $2.99 USD one-time (no in-app purchases, no subscription, no ads)
 - **Platforms:** iPhone, iPad, Apple Watch, Mac, Apple TV (SwiftUI; one target, multiple destinations + an embedded Watch target)
 
-## Strategy lives in the private hub
+## Strategy lives in a private hub
 
-Target audience, positioning, pricing reasoning, SEO/ASO playbooks, and competitor analysis are **not** in this public repo — they're in the private [iamjarl-strategy](https://github.com/JarlLyng/iamjarl-strategy) hub (folder `WODrounds/`). Before doing any audience/positioning/pricing/marketing-planning work, read that repo's `CONVENTIONS.md` and write results there, not here.
+Target audience, positioning, pricing reasoning, SEO/ASO playbooks, and competitor analysis are **not** in this public repo. They live in a separate private strategy hub. Before doing any audience, positioning, pricing, or marketing-planning work, read that hub's `CONVENTIONS.md` and write results there, not here.
 
-## App features (be precise — do not invent features that don't exist)
+## App features (be precise; do not invent features that don't exist)
 
-- **EMOM** — set rounds (1–120) and a custom round length (0:30–9:30, 30s steps); round counter + per-round countdown.
-- **Intervals** — work / rest / rounds, each adjustable; phase display (Work / Rest). Total = `rounds × work + (rounds − 1) × rest` (no rest after last work).
-- **Tabata** — a manual Intervals preset (e.g. 20/10 × 8), not a separate mode.
+- **EMOM:** set rounds (1–120) and a custom round length (0:30–9:30, 30s steps); round counter + per-round countdown.
+- **Intervals:** work / rest / rounds, each adjustable; phase display (Work / Rest). Total = `rounds × work + (rounds − 1) × rest` (no rest after last work).
+- **Tabata:** a manual Intervals preset (e.g. 20/10 × 8), not a separate mode.
 - Start / Pause / Resume / Reset / Cancel; Done screen on completion.
 - **iPhone → Watch sync** via WatchConnectivity (start on iPhone, follow on Watch).
-- **Date-based timing** — reliable when backgrounded; deterministic engine (`Shared/WODTimerEngine.swift`), no UI/sound in the engine.
+- **Date-based timing:** reliable when backgrounded; deterministic engine (`Shared/WODTimerEngine.swift`), no UI/sound in the engine.
 - Sound cues (count-in, halfway, 10s, 3-2-1, rounds-remaining), haptics (iOS), HealthKit save as HIIT (iOS only).
 
 ### Features that do NOT exist (common hallucination targets)
-- No workout *tracking* / history / logbook — it's a timer, not a tracker.
+- No AMRAP or For Time modes; only EMOM and Intervals. (For Time is a possible future feature, not built.)
+- No workout *tracking* / history / logbook; it's a timer, not a tracker.
 - No social, sharing, or accounts.
 - No cloud sync or internet dependency.
 
@@ -38,5 +39,5 @@ Target audience, positioning, pricing reasoning, SEO/ASO playbooks, and competit
 - Docs: run `python3 scripts/validate_docs.py` before committing docs changes (also enforced by `.github/workflows/docs.yml`).
 
 ## Conventions
-- Uses `iamjarl-design` tokens via SPM — `DesignTokens.swift` re-exports the package and adds app-specific font sizes; no hardcoded colors.
+- Uses `iamjarl-design` tokens via SPM; `DesignTokens.swift` re-exports the package and adds app-specific font sizes; no hardcoded colors.
 - Privacy-first: no tracking; HealthKit writes stay on-device.


### PR DESCRIPTION
Adopts the shared IAMJARL project standards (defined in the private `iamjarl-strategy` hub).

**Adds:**
- `.github/ISSUE_TEMPLATE/` — `bug_report.yml`, `feature_request.yml`, `marketing_idea.yml`, `config.yml` (`blank_issues_enabled: false`, support + security contact links).
- `.github/pull_request_template.md`.
- `CLAUDE.md` — AI/dev context (features incl. a "features that do NOT exist" list; points strategy work at the private hub).

The `marketing_idea` form enforces the public-safe vs private-hub split: competitive-sensitive strategy stays in the private repo, never in a public issue.

Please review feature accuracy in `CLAUDE.md` before merging.
