### PR TITLE
Add For Time timer mode (1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable user-facing changes to WODrounds. Newest first.
 
+## 1.5 (build 13)
+
+**What's New (App Store copy):**
+
+> • New: For Time mode. The clock counts up from zero; press Stop when you finish and your time is saved. Set an optional time cap and the timer stops there automatically.
+> • For Time works on iPhone, iPad, Mac and Apple TV, and your Apple Watch follows along when you start on iPhone.
+> • Small fixes and polish.
+
+**Details:**
+
+- **Added:** For Time timer mode (#15): counts up from zero. Two variants: uncapped (runs until you press Stop) and capped (auto-finishes at the cap; 0:30–60:00 in 30s steps via a single "Time cap" stepper whose 0 position reads "No cap"). The Done screen shows "Finished in MM:SS" and the workout saves to Apple Health with the real active time (pauses excluded, time frozen at Stop).
+- **Added:** Apple Watch follows a synced For Time workout: elapsed time counts up on the wrist, no round display.
+- **Changed:** In For Time the primary button during a run is **Stop** (a For Time clock isn't paused); Cancel still discards the workout. In-round audio cues (halfway, ten-seconds, 3-2-1, rounds-remaining) don't apply to For Time and stay silent; the completion sound still plays.
+- **Internal:** Timer engine gained `finish(now:)` (freezes the final time) and an `elapsedTime` snapshot field; the Watch sync payload carries `capSeconds`/`finishedAt`. Full unit-test coverage for the new mode.
+
 ## 1.4 (build 12)
 
 **What's New (App Store copy):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Quick-start context for developers and AI assistants. Detailed specs in `docs/`.
 
 ## What is WODrounds?
 
-A minimal SwiftUI interval timer for CrossFit, EMOM, Tabata and intervals across iPhone, iPad, Apple Watch, Mac and Apple TV. A single-purpose tool: **not** social, **not** workout tracking. No accounts, no ads, no subscription. Start a workout on iPhone and follow it on Watch (one workout, one synced state).
+A minimal SwiftUI interval timer for CrossFit — EMOM, Intervals (Tabata) and For Time — across iPhone, iPad, Apple Watch, Mac and Apple TV. A single-purpose tool: **not** social, **not** workout tracking. No accounts, no ads, no subscription. Start a workout on iPhone and follow it on Watch (one workout, one synced state).
 
 - **Developer:** Jarl Lyng / [IAMJARL](https://iamjarl.com)
 - **Website:** [wodrounds.iamjarl.com](https://wodrounds.iamjarl.com)
@@ -22,13 +22,14 @@ Target audience, positioning, pricing reasoning, SEO/ASO playbooks, and competit
 - **EMOM:** set rounds (1–120) and a custom round length (0:30–9:30, 30s steps); round counter + per-round countdown.
 - **Intervals:** work / rest / rounds, each adjustable; phase display (Work / Rest). Total = `rounds × work + (rounds − 1) × rest` (no rest after last work).
 - **Tabata:** a manual Intervals preset (e.g. 20/10 × 8), not a separate mode.
-- Start / Pause / Resume / Reset / Cancel; Done screen on completion.
+- **For Time (new in 1.5):** counts up from zero; optional time cap (0:30–60:00, 30s steps; 0 = "No cap"). Uncapped runs until Stop; capped auto-finishes at the cap. Stop freezes the final time; Done screen shows "Finished in MM:SS". No rounds, no in-round cues. Watch follows a synced For Time (no local Watch For Time).
+- Start / Pause / Resume / Reset / Cancel; Done screen on completion. For Time uses Stop instead of Pause while running.
 - **iPhone → Watch sync** via WatchConnectivity (start on iPhone, follow on Watch).
 - **Date-based timing:** reliable when backgrounded; deterministic engine (`Shared/WODTimerEngine.swift`), no UI/sound in the engine.
 - Sound cues (count-in, halfway, 10s, 3-2-1, rounds-remaining), haptics (iOS), HealthKit save as HIIT (iOS only).
 
 ### Features that do NOT exist (common hallucination targets)
-- No AMRAP or For Time modes; only EMOM and Intervals. (For Time is a possible future feature, not built.)
+- No AMRAP mode; the modes are EMOM, Intervals, and For Time (For Time added in 1.5).
 - No workout *tracking* / history / logbook; it's a timer, not a tracker.
 - No social, sharing, or accounts.
 - No cloud sync or internet dependency.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WODrounds — EMOM & Interval Timer for CrossFit and HIIT
+# WODrounds — EMOM, Interval & For Time Timer for CrossFit and HIIT
 
-Minimal SwiftUI timer for CrossFit, EMOM, Tabata and intervals on iPhone, iPad, Apple Watch, Mac and Apple TV. No accounts, no ads, no subscription — a single-purpose tool (not social, not workout tracking).
+Minimal SwiftUI timer for CrossFit — EMOM, Tabata, intervals and For Time — on iPhone, iPad, Apple Watch, Mac and Apple TV. No accounts, no ads, no subscription — a single-purpose tool (not social, not workout tracking).
 
 **[wodrounds.iamjarl.com](https://wodrounds.iamjarl.com)** · [App Store](https://apps.apple.com/app/wodrounds/id6759229877)
 
@@ -24,7 +24,13 @@ Minimal SwiftUI timer for CrossFit, EMOM, Tabata and intervals on iPhone, iPad, 
 
 Tabata (e.g. 20/10 × 8) is a manual Intervals preset.
 
-**In-app flow:** Choose EMOM or Intervals → set rounds (and for Intervals: work/rest) → Start → timer runs → Pause/Resume or Cancel → on completion, Done screen → Reset returns to setup.
+### For Time
+- Counts **up** from zero — for classic "complete the work as fast as you can" WODs.
+- Optional **time cap** (0:30–60:00, 30s steps; one stepper where 0 reads "No cap"). Uncapped runs until you press **Stop**; capped auto-finishes at the cap.
+- Stop freezes your final time; the Done screen shows "Finished in MM:SS". No rounds, no in-round audio cues. Saves to Apple Health like the other modes.
+- Apple Watch follows a synced For Time workout (count-up on the wrist); there is no local For Time mode on the Watch.
+
+**In-app flow:** Choose EMOM, Intervals or For Time → set rounds (Intervals: work/rest; For Time: optional cap) → Start → timer runs → Pause/Resume (EMOM/Intervals), Stop (For Time) or Cancel → on completion, Done screen → Reset returns to setup.
 
 ---
 
@@ -38,7 +44,7 @@ Tabata (e.g. 20/10 × 8) is a manual Intervals preset.
 ### Main app (WODrounds)
 
 **Core files:**
-- **Shared/WODTimerEngine.swift** — Shared with Watch target. State machine for EMOM + Intervals; Date-based, deterministic; no UI/sound/haptics. `effectiveWorkoutEndDate(now:)` for HealthKit active-time.
+- **Shared/WODTimerEngine.swift** — Shared with Watch target. State machine for EMOM + Intervals + For Time; Date-based, deterministic; no UI/sound/haptics. `effectiveWorkoutEndDate(now:)` for HealthKit active-time.
 - **WODTimerSync.swift** — Sends timer state to Watch via WatchConnectivity.
 - **DesignTokens.swift** — Re-exports IAMJARL design tokens from SPM package; adds app-specific font sizes.
 - **ContentView.swift** — Shared types (ranges, `TimerUIMode` enum) used by all platform views.
@@ -53,8 +59,9 @@ Tabata (e.g. 20/10 × 8) is a manual Intervals preset.
 **Engine behaviour:**
 - Platform-agnostic (Foundation only).
 - Date-based: elapsed = now − startDate − accumulatedPauseDuration; no frame timers.
-- Actions: start(now:), pause(now:), resume(now:), reset(), tick(now:).
-- Snapshot: state, remainingTime, currentRound, currentPhase (work/rest), remainingTimeInPhase, secondsIntoCurrentMinute (EMOM).
+- Actions: start(now:), pause(now:), resume(now:), reset(), tick(now:), finish(now:) (For Time Stop — freezes the final time).
+- Snapshot: state, remainingTime, elapsedTime (count-up headline for For Time), currentRound, currentPhase (work/rest), remainingTimeInPhase, secondsIntoCurrentMinute (EMOM).
+- For Time: `forTime(capSeconds: Int?)` — nil is uncapped (no total; never auto-finishes), otherwise auto-finishes at the cap.
 
 ### Watch app (WODrounds Watch)
 

--- a/Shared/WODTimerEngine.swift
+++ b/Shared/WODTimerEngine.swift
@@ -24,8 +24,11 @@ enum WODTimerPhase: Equatable {
 /// Snapshot of timer state at a given moment. All values derived from Date.
 struct WODTimerEngineSnapshot {
     let state: WODTimerEngineState
-    /// Total seconds remaining in the workout (0 when finished or idle).
+    /// Total seconds remaining in the workout (0 when finished or idle; 0 for uncapped For Time).
     let remainingTime: TimeInterval
+    /// Seconds elapsed since start, excluding pauses. Frozen at the final time once finished.
+    /// The headline value for For Time (count-up); informational for EMOM/Intervals.
+    let elapsedTime: TimeInterval
     /// Current round, 1-based.
     let currentRound: Int
     /// Seconds elapsed within the current minute (EMOM) or N/A (Intervals).
@@ -36,10 +39,12 @@ struct WODTimerEngineSnapshot {
     let remainingTimeInPhase: TimeInterval
 }
 
-/// Timer mode: EMOM (rounds, secondsPerRound) or Intervals (work/rest/rounds).
+/// Timer mode: EMOM (rounds, secondsPerRound), Intervals (work/rest/rounds),
+/// or For Time (count-up; capSeconds nil = uncapped).
 enum WODTimerMode: Equatable {
     case emom(rounds: Int, secondsPerRound: Int)
     case intervals(workSeconds: Int, restSeconds: Int, rounds: Int)
+    case forTime(capSeconds: Int?)
 }
 
 /// EMOM + Intervals timer engine. Date-based, deterministic.
@@ -51,6 +56,8 @@ struct WODTimerEngine {
     private var startDate: Date?
     private var accumulatedPauseDuration: TimeInterval = 0
     private var pausedAt: Date?
+    /// Set by finish(now:) so the final elapsed time is frozen (Done screen, HealthKit).
+    private var finishedAt: Date?
 
     private let secondsPerMinute: TimeInterval = 60
 
@@ -91,30 +98,57 @@ struct WODTimerEngine {
         return totalDurationMinutes
     }
 
-    /// Total duration in seconds (for display). EMOM: rounds * secondsPerRound. Intervals: rounds * work + (rounds - 1) * rest.
+    // MARK: - For Time
+
+    /// Count-up mode. capSeconds nil = uncapped (runs until the user stops it);
+    /// non-nil = auto-finishes when elapsed reaches the cap.
+    init(forTimeCapSeconds: Int?) {
+        self.mode = .forTime(capSeconds: forTimeCapSeconds.map { max(1, $0) })
+    }
+
+    /// Time cap in seconds for For Time (nil when uncapped or not in For Time mode).
+    var forTimeCapSeconds: Int? {
+        if case .forTime(let cap) = mode { return cap }
+        return nil
+    }
+
+    /// True for For Time with no cap: the only mode with no fixed total, so every
+    /// `elapsed >= totalDurationSeconds` auto-finish comparison must be skipped
+    /// (totalDurationSeconds is 0 and would finish instantly).
+    private var isUncappedForTime: Bool {
+        if case .forTime(let cap) = mode { return cap == nil }
+        return false
+    }
+
+    /// Total duration in seconds (for display). EMOM: rounds * secondsPerRound.
+    /// Intervals: rounds * work + (rounds - 1) * rest. For Time: cap, or 0 when uncapped.
     var totalDurationSeconds: TimeInterval {
         switch mode {
         case .emom(let r, let spr):
             return TimeInterval(r) * TimeInterval(spr)
         case .intervals(let w, let r, let n):
             return TimeInterval(n) * TimeInterval(w) + TimeInterval(n - 1) * TimeInterval(r)
+        case .forTime(let cap):
+            return TimeInterval(cap ?? 0)
         }
     }
 
     // MARK: - Actions
 
     mutating func start(now: Date) {
-        guard totalDurationSeconds > 0 else { return }
+        // Uncapped For Time deliberately has no total; every other mode needs one.
+        guard totalDurationSeconds > 0 || isUncappedForTime else { return }
         startDate = now
         accumulatedPauseDuration = 0
         pausedAt = nil
+        finishedAt = nil
         state = .running
     }
 
     mutating func pause(now: Date) {
         guard state == .running, let start = startDate else { return }
         let elapsed = now.timeIntervalSince(start) - accumulatedPauseDuration
-        if elapsed >= totalDurationSeconds {
+        if !isUncappedForTime, elapsed >= totalDurationSeconds {
             state = .finished
             return
         }
@@ -129,11 +163,25 @@ struct WODTimerEngine {
         state = .running
     }
 
+    /// Explicitly end the workout now (For Time "Stop"). Freezes the final elapsed
+    /// time via finishedAt so the Done screen and HealthKit don't keep growing.
+    mutating func finish(now: Date) {
+        guard state == .running || state == .paused else { return }
+        // Fold an open pause into the accumulated total so frozen elapsed excludes it.
+        if let pauseStart = pausedAt {
+            accumulatedPauseDuration += max(0, now.timeIntervalSince(pauseStart))
+            pausedAt = nil
+        }
+        finishedAt = now
+        state = .finished
+    }
+
     mutating func reset() {
         state = .idle
         startDate = nil
         accumulatedPauseDuration = 0
         pausedAt = nil
+        finishedAt = nil
     }
 
     /// End date for a HealthKit workout so duration = active time (excludes pause). Nil if workout never started.
@@ -153,17 +201,17 @@ struct WODTimerEngine {
     func snapshot(now: Date) -> WODTimerEngineSnapshot {
         switch state {
         case .idle:
-            return makeSnapshot(state: .idle, remainingTime: 0, currentRound: 0, secondsIntoCurrentMinute: 0, phase: .work, remainingTimeInPhase: 0)
+            return makeSnapshot(state: .idle, remainingTime: 0, elapsedTime: 0, currentRound: 0, secondsIntoCurrentMinute: 0, phase: .work, remainingTimeInPhase: 0)
         case .running:
             let elapsed = elapsedSeconds(now: now)
             let total = totalDurationSeconds
-            if elapsed >= total {
+            if !isUncappedForTime, elapsed >= total {
                 return makeFinishedSnapshot()
             }
             return snapshotForActive(elapsed: elapsed)
         case .paused:
             let elapsed = elapsedSeconds(now: now)
-            if elapsed >= totalDurationSeconds {
+            if !isUncappedForTime, elapsed >= totalDurationSeconds {
                 return makeFinishedSnapshot()
             }
             return snapshotForPaused(elapsed: elapsed)
@@ -174,6 +222,7 @@ struct WODTimerEngine {
 
     mutating func tick(now: Date) {
         guard state == .running else { return }
+        guard !isUncappedForTime else { return } // uncapped For Time never auto-finishes
         let elapsed = elapsedSeconds(now: now)
         if elapsed >= totalDurationSeconds {
             state = .finished
@@ -197,10 +246,11 @@ struct WODTimerEngine {
         return max(0, raw)
     }
 
-    private func makeSnapshot(state: WODTimerEngineState, remainingTime: TimeInterval, currentRound: Int, secondsIntoCurrentMinute: Int, phase: WODTimerPhase, remainingTimeInPhase: TimeInterval) -> WODTimerEngineSnapshot {
+    private func makeSnapshot(state: WODTimerEngineState, remainingTime: TimeInterval, elapsedTime: TimeInterval, currentRound: Int, secondsIntoCurrentMinute: Int, phase: WODTimerPhase, remainingTimeInPhase: TimeInterval) -> WODTimerEngineSnapshot {
         WODTimerEngineSnapshot(
             state: state,
             remainingTime: remainingTime,
+            elapsedTime: elapsedTime,
             currentRound: currentRound,
             secondsIntoCurrentMinute: secondsIntoCurrentMinute,
             currentPhase: phase,
@@ -208,13 +258,23 @@ struct WODTimerEngine {
         )
     }
 
+    /// Final elapsed time once finished. finish(now:) freezes the exact time via
+    /// finishedAt; auto-finished workouts (cap/total reached) use the full duration.
+    private var finishedElapsedTime: TimeInterval {
+        if let finishedAt, let start = startDate {
+            return max(0, finishedAt.timeIntervalSince(start) - accumulatedPauseDuration)
+        }
+        return totalDurationSeconds
+    }
+
     private func makeFinishedSnapshot() -> WODTimerEngineSnapshot {
         let totalRounds: Int
         switch mode {
         case .emom(let r, _): totalRounds = r
         case .intervals(_, _, let r): totalRounds = r
+        case .forTime: totalRounds = 1 // For Time has no rounds; UI hides the label
         }
-        return makeSnapshot(state: .finished, remainingTime: 0, currentRound: totalRounds, secondsIntoCurrentMinute: 0, phase: .work, remainingTimeInPhase: 0)
+        return makeSnapshot(state: .finished, remainingTime: 0, elapsedTime: finishedElapsedTime, currentRound: totalRounds, secondsIntoCurrentMinute: 0, phase: .work, remainingTimeInPhase: 0)
     }
 
     private func snapshotForActive(elapsed: TimeInterval) -> WODTimerEngineSnapshot {
@@ -225,12 +285,15 @@ struct WODTimerEngine {
             let round = min(roundFromEMOM(elapsed: elapsed), rounds)
             let intoRound = elapsed >= total ? 0 : secondsIntoMinuteFrom(elapsed: elapsed)
             let remainingTimeInPhase = TimeInterval(spr - intoRound)
-            return makeSnapshot(state: .running, remainingTime: remaining, currentRound: round, secondsIntoCurrentMinute: intoRound, phase: .work, remainingTimeInPhase: remainingTimeInPhase)
+            return makeSnapshot(state: .running, remainingTime: remaining, elapsedTime: elapsed, currentRound: round, secondsIntoCurrentMinute: intoRound, phase: .work, remainingTimeInPhase: remainingTimeInPhase)
         case .intervals(let w, let r, let n):
             let total = totalDurationSeconds
             let remaining = max(0, total - elapsed)
             let (round, phase, remainingTimeInPhase) = intervalsPhase(elapsed: elapsed, work: w, rest: r, rounds: n)
-            return makeSnapshot(state: .running, remainingTime: remaining, currentRound: round, secondsIntoCurrentMinute: 0, phase: phase, remainingTimeInPhase: remainingTimeInPhase)
+            return makeSnapshot(state: .running, remainingTime: remaining, elapsedTime: elapsed, currentRound: round, secondsIntoCurrentMinute: 0, phase: phase, remainingTimeInPhase: remainingTimeInPhase)
+        case .forTime(let cap):
+            let remaining = cap.map { max(0, TimeInterval($0) - elapsed) } ?? 0
+            return makeSnapshot(state: .running, remainingTime: remaining, elapsedTime: elapsed, currentRound: 1, secondsIntoCurrentMinute: 0, phase: .work, remainingTimeInPhase: remaining)
         }
     }
 
@@ -242,12 +305,15 @@ struct WODTimerEngine {
             let round = roundFromEMOM(elapsed: elapsed)
             let intoRound = secondsIntoMinuteFrom(elapsed: elapsed)
             let remainingTimeInPhase = TimeInterval(spr - intoRound)
-            return makeSnapshot(state: .paused, remainingTime: remaining, currentRound: round, secondsIntoCurrentMinute: intoRound, phase: .work, remainingTimeInPhase: remainingTimeInPhase)
+            return makeSnapshot(state: .paused, remainingTime: remaining, elapsedTime: elapsed, currentRound: round, secondsIntoCurrentMinute: intoRound, phase: .work, remainingTimeInPhase: remainingTimeInPhase)
         case .intervals(let w, let r, let n):
             let total = totalDurationSeconds
             let remaining = max(0, total - elapsed)
             let (round, phase, remainingTimeInPhase) = intervalsPhase(elapsed: elapsed, work: w, rest: r, rounds: n)
-            return makeSnapshot(state: .paused, remainingTime: remaining, currentRound: round, secondsIntoCurrentMinute: 0, phase: phase, remainingTimeInPhase: remainingTimeInPhase)
+            return makeSnapshot(state: .paused, remainingTime: remaining, elapsedTime: elapsed, currentRound: round, secondsIntoCurrentMinute: 0, phase: phase, remainingTimeInPhase: remainingTimeInPhase)
+        case .forTime(let cap):
+            let remaining = cap.map { max(0, TimeInterval($0) - elapsed) } ?? 0
+            return makeSnapshot(state: .paused, remainingTime: remaining, elapsedTime: elapsed, currentRound: 1, secondsIntoCurrentMinute: 0, phase: .work, remainingTimeInPhase: remaining)
         }
     }
 
@@ -298,20 +364,25 @@ struct WODTimerEngine {
         let startDate: Date?
         let accumulatedPauseDuration: TimeInterval
         let pausedAt: Date?
-        let mode: String        // "emom" | "intervals"
+        let mode: String        // "emom" | "intervals" | "forTime"
         let totalMinutes: Int
         let emomSecondsPerRound: Int?
         let workSeconds: Int?
         let restSeconds: Int?
         let rounds: Int?
+        /// For Time cap; nil when uncapped or in another mode. Optional so old payloads decode.
+        let capSeconds: Int?
+        /// When finish(now:) froze the workout; lets the Watch freeze elapsed too.
+        let finishedAt: Date?
         let lastUpdated: Date
     }
 
     func syncPayload(now: Date) -> SyncPayload {
-        let (modeStr, totalMin, spr, work, rest, rnds): (String, Int, Int?, Int?, Int?, Int?) = {
+        let (modeStr, totalMin, spr, work, rest, rnds, cap): (String, Int, Int?, Int?, Int?, Int?, Int?) = {
             switch mode {
-            case .emom(let m, let s): return ("emom", m, s, nil, nil, nil)
-            case .intervals(let w, let r, let n): return ("intervals", 0, nil, w, r, n)
+            case .emom(let m, let s): return ("emom", m, s, nil, nil, nil, nil)
+            case .intervals(let w, let r, let n): return ("intervals", 0, nil, w, r, n, nil)
+            case .forTime(let c): return ("forTime", 0, nil, nil, nil, nil, c)
             }
         }()
         return SyncPayload(
@@ -325,6 +396,8 @@ struct WODTimerEngine {
             workSeconds: work,
             restSeconds: rest,
             rounds: rnds,
+            capSeconds: cap,
+            finishedAt: finishedAt,
             lastUpdated: now
         )
     }

--- a/WODrounds.xcodeproj/project.pbxproj
+++ b/WODrounds.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=appletvos*]" = "WODrounds/WODrounds-tvOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "WODrounds/WODrounds-Mac.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				ENABLE_APP_SANDBOX = YES;
@@ -587,7 +587,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
@@ -614,7 +614,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=appletvos*]" = "WODrounds/WODrounds-tvOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "WODrounds/WODrounds-Mac.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				ENABLE_APP_SANDBOX = YES;
@@ -642,7 +642,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
@@ -664,13 +664,13 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -690,13 +690,13 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -715,13 +715,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -740,13 +740,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -768,14 +768,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WODroundsWatch/WODroundsWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "WODroundsWatch-Info.plist";
 				INFOPLIST_KEY_CFBundleIconName = AppIcon;
 				INFOPLIST_KEY_LSApplicationCategory = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.iamjarl.WODrounds;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -795,14 +795,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WODroundsWatch/WODroundsWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "WODroundsWatch-Info.plist";
 				INFOPLIST_KEY_CFBundleIconName = AppIcon;
 				INFOPLIST_KEY_LSApplicationCategory = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.iamjarl.WODrounds;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/WODrounds/ContentView.swift
+++ b/WODrounds/ContentView.swift
@@ -17,9 +17,24 @@ let emomLengthRange = 30 ... 570
 let intervalsWorkRange = 5 ... 300
 let intervalsRestRange = 0 ... 180
 let intervalsRoundsRange = 1 ... 60
+/// For Time cap stepper range. 0 is the "No cap" sentinel; real caps run
+/// 0:30–60:00 in 30s steps, so a single stepper covers both (0 ↔ 0:30 ↔ 1:00 …).
+let forTimeCapRange = 0 ... 3600
+let forTimeCapStep = 30
+
+/// Stepper display for the For Time cap: the 0 sentinel reads "No cap".
+func forTimeCapDisplay(_ seconds: Int) -> String {
+    seconds == 0 ? "No cap" : sharedFormatEmomLength(seconds)
+}
+
+/// Engine cap value from the stepper value (0 sentinel → nil = uncapped).
+func forTimeEngineCap(_ seconds: Int) -> Int? {
+    seconds == 0 ? nil : seconds
+}
 
 enum TimerUIMode: String, CaseIterable {
     case emom = "EMOM"
     case intervals = "Intervals"
+    case forTime = "For Time"
 }
 #endif

--- a/WODrounds/SharedTimerViews.swift
+++ b/WODrounds/SharedTimerViews.swift
@@ -135,6 +135,8 @@ struct ModeSwitchTheme {
 struct SharedDoneView: View {
     var totalRounds: Int
     var theme: DoneViewTheme
+    /// When set (For Time), the body line shows the finished time instead of rounds.
+    var finishedTime: TimeInterval? = nil
     @Environment(\.colorScheme) private var scheme
 
     var body: some View {
@@ -145,12 +147,20 @@ struct SharedDoneView: View {
             Text("Done")
                 .font(.system(size: theme.titleSize, weight: DesignTokens.Typography.Weight.bold, design: .monospaced))
                 .foregroundStyle(DesignTokens.Common.Text.primary(scheme))
-            Text("You completed \(totalRounds) round\(totalRounds == 1 ? "" : "s")")
+            Text(bodyLine)
                 .font(.system(size: theme.bodySize, weight: DesignTokens.Typography.Weight.regular, design: .monospaced))
                 .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
         }
         .padding(.vertical, theme.verticalSpacing)
         .accessibilityElement(children: .combine)
+    }
+
+    private var bodyLine: String {
+        if let finishedTime {
+            // Floor: the athlete's time is the last full second reached.
+            return "Finished in \(sharedTimeString(from: floor(finishedTime)))"
+        }
+        return "You completed \(totalRounds) round\(totalRounds == 1 ? "" : "s")"
     }
 }
 

--- a/WODrounds/iOSContentView.swift
+++ b/WODrounds/iOSContentView.swift
@@ -430,6 +430,8 @@ private struct iOSContent: View {
     /// Idempotent — each cue fires at most once per (round, phase) tuple.
     private func checkInRoundCues(now: Date) {
         guard engine.state == .running else { return }
+        // For Time counts up with no rounds/phases — none of the in-round cues apply.
+        if case .forTime = engine.mode { return }
         let snapshot = engine.snapshot(now: now)
         let remaining = snapshot.remainingTimeInPhase
         let round = snapshot.currentRound
@@ -442,6 +444,8 @@ private struct iOSContent: View {
                 return TimeInterval(spr)
             case .intervals(let w, let r, _):
                 return TimeInterval(phase == .work ? w : r)
+            case .forTime:
+                return 0 // unreachable (guarded above); keeps the switch exhaustive
             }
         }()
 

--- a/WODrounds/iOSContentView.swift
+++ b/WODrounds/iOSContentView.swift
@@ -30,6 +30,8 @@ struct ContentView: View {
     @State private var intervalsWork: Int = 30
     @State private var intervalsRest: Int = 15
     @State private var intervalsRounds: Int = 8
+    // For Time cap; 0 = "No cap" sentinel (see forTimeCapRange).
+    @AppStorage("forTimeCapSeconds") private var forTimeCapSeconds: Int = 0
     @State private var engine = WODTimerEngine(emomRounds: 10, secondsPerRound: 60)
 
     var body: some View {
@@ -42,6 +44,7 @@ struct ContentView: View {
                 intervalsWork: $intervalsWork,
                 intervalsRest: $intervalsRest,
                 intervalsRounds: $intervalsRounds,
+                forTimeCap: $forTimeCapSeconds,
                 now: timeline.date
             )
             .onChange(of: timeline.date) { newDate in
@@ -68,6 +71,7 @@ private struct iOSContent: View {
     @Binding var intervalsWork: Int
     @Binding var intervalsRest: Int
     @Binding var intervalsRounds: Int
+    @Binding var forTimeCap: Int
     let now: Date
     @Environment(\.colorScheme) private var scheme
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -233,7 +237,8 @@ private struct iOSContent: View {
             Spacer()
 
             if snapshot.state == .finished {
-                SharedDoneView(totalRounds: totalRounds, theme: doneTheme)
+                SharedDoneView(totalRounds: totalRounds, theme: doneTheme,
+                               finishedTime: timerMode == .forTime ? snapshot.elapsedTime : nil)
                     .transition(.opacity)
             } else if snapshot.state == .running || snapshot.state == .paused {
                 activeTimerView(snapshot: snapshot, totalRounds: totalRounds)
@@ -280,15 +285,26 @@ private struct iOSContent: View {
 
     private func activeTimerView(snapshot: WODTimerEngineSnapshot, totalRounds: Int) -> some View {
         VStack(spacing: DesignTokens.Spacing.lg * spacingScale) {
-            Text(sharedTimeString(from: timerMode == .emom ? snapshot.remainingTimeInPhase : snapshot.remainingTime))
+            // For Time counts up (floored so the shown time never runs ahead);
+            // EMOM shows the per-round countdown; Intervals the total countdown.
+            Text(sharedTimeString(from: activeDisplayTime(snapshot: snapshot)))
                 .font(.system(size: DesignTokens.Typography.Size.display * fontScale, weight: DesignTokens.Typography.Weight.bold, design: .monospaced))
                 .monospacedDigit()
                 .foregroundStyle(DesignTokens.Common.Text.primary(scheme))
                 .frame(maxWidth: .infinity)
 
-            Text(sharedRoundLabel(snapshot: snapshot, totalRounds: totalRounds))
-                .font(.system(size: DesignTokens.Typography.Size.lg * fontScale, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
-                .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+            if timerMode == .forTime {
+                // No rounds in For Time; show the cap as context when one is set.
+                if let cap = engine.forTimeCapSeconds {
+                    Text("Cap \(sharedFormatEmomLength(cap))")
+                        .font(.system(size: DesignTokens.Typography.Size.lg * fontScale, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
+                        .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+                }
+            } else {
+                Text(sharedRoundLabel(snapshot: snapshot, totalRounds: totalRounds))
+                    .font(.system(size: DesignTokens.Typography.Size.lg * fontScale, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
+                    .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+            }
 
             if timerMode == .intervals {
                 Text(snapshot.currentPhase == .work ? "Work" : "Rest")
@@ -297,6 +313,14 @@ private struct iOSContent: View {
             }
         }
         .transition(.opacity)
+    }
+
+    private func activeDisplayTime(snapshot: WODTimerEngineSnapshot) -> TimeInterval {
+        switch timerMode {
+        case .emom: return snapshot.remainingTimeInPhase
+        case .intervals: return snapshot.remainingTime
+        case .forTime: return floor(snapshot.elapsedTime)
+        }
     }
 
     private func idleSettingsView(state: WODTimerEngineState) -> some View {
@@ -316,6 +340,14 @@ private struct iOSContent: View {
             .opacity(timerMode == .intervals ? 1 : 0)
             .allowsHitTesting(timerMode == .intervals)
             .accessibilityHidden(timerMode != .intervals)
+            VStack(spacing: DesignTokens.Spacing.lg * spacingScale) {
+                // Single stepper covers both "no cap" and the cap value: the 0
+                // sentinel renders as "No cap" and steps to 0:30, 1:00, … 60:00.
+                SharedStepperView(value: $forTimeCap, range: forTimeCapRange, step: forTimeCapStep, displayString: forTimeCapDisplay(forTimeCap), label: "Time cap", onChange: { syncEngineIfIdle(state) }, theme: stepperTheme, useLongPressRepeat: true)
+            }
+            .opacity(timerMode == .forTime ? 1 : 0)
+            .allowsHitTesting(timerMode == .forTime)
+            .accessibilityHidden(timerMode != .forTime)
         }
     }
 
@@ -514,6 +546,8 @@ private struct iOSContent: View {
             return "Select the number of rounds, and length of each round."
         case .intervals:
             return "Set work time, rest time, and number of rounds."
+        case .forTime:
+            return "The clock counts up. Press Stop when you finish, or set an optional time cap."
         }
     }
 
@@ -524,6 +558,8 @@ private struct iOSContent: View {
             engine = WODTimerEngine(emomRounds: rounds, secondsPerRound: emomRoundLength)
         case .intervals:
             engine = WODTimerEngine(workSeconds: intervalsWork, restSeconds: intervalsRest, rounds: intervalsRounds)
+        case .forTime:
+            engine = WODTimerEngine(forTimeCapSeconds: forTimeEngineCap(forTimeCap))
         }
     }
 
@@ -537,7 +573,13 @@ private struct iOSContent: View {
                     countdownEndTime = Date().addingTimeInterval(10)
                 }
             })
-        case .running: ("Pause", { var e = engine; e.pause(now: now); engine = e; WODTimerSync.write(engine.syncPayload(now: now)) })
+        case .running:
+            // For Time: the clock runs until you stop it (a For Time WOD isn't
+            // paused). Stop freezes the final time via finish(now:); Cancel below
+            // still discards. Other modes keep Pause.
+            timerMode == .forTime
+                ? ("Stop", { var e = engine; e.finish(now: now); engine = e; WODTimerSync.write(engine.syncPayload(now: now)) })
+                : ("Pause", { var e = engine; e.pause(now: now); engine = e; WODTimerSync.write(engine.syncPayload(now: now)) })
         case .paused: ("Resume", { var e = engine; e.resume(now: now); engine = e; WODTimerSync.write(engine.syncPayload(now: now)) })
         case .finished: ("Reset", {
             let endDate = engine.effectiveWorkoutEndDate(now: now) ?? now

--- a/WODrounds/macOSContentView.swift
+++ b/WODrounds/macOSContentView.swift
@@ -15,6 +15,8 @@ struct ContentView: View {
     @State private var intervalsWork: Int = 30
     @State private var intervalsRest: Int = 15
     @State private var intervalsRounds: Int = 8
+    // For Time cap; 0 = "No cap" sentinel (see forTimeCapRange).
+    @AppStorage("forTimeCapSeconds") private var forTimeCapSeconds: Int = 0
     @State private var engine = WODTimerEngine(emomRounds: 10, secondsPerRound: 60)
 
     @Environment(\.colorScheme) private var scheme
@@ -34,6 +36,7 @@ struct ContentView: View {
                 intervalsWork: $intervalsWork,
                 intervalsRest: $intervalsRest,
                 intervalsRounds: $intervalsRounds,
+                forTimeCap: $forTimeCapSeconds,
                 now: timeline.date
             )
             .onChange(of: timeline.date) { newDate in
@@ -59,6 +62,7 @@ private struct MacContent: View {
     @Binding var intervalsWork: Int
     @Binding var intervalsRest: Int
     @Binding var intervalsRounds: Int
+    @Binding var forTimeCap: Int
     let now: Date
     @Environment(\.colorScheme) private var scheme
 
@@ -165,7 +169,8 @@ private struct MacContent: View {
             }
 
             if snapshot.state == .finished {
-                SharedDoneView(totalRounds: totalRounds, theme: Self.macDoneTheme)
+                SharedDoneView(totalRounds: totalRounds, theme: Self.macDoneTheme,
+                               finishedTime: timerMode == .forTime ? snapshot.elapsedTime : nil)
                     .transition(.opacity)
             } else if snapshot.state == .running || snapshot.state == .paused {
                 activeTimerView(snapshot: snapshot, totalRounds: totalRounds)
@@ -205,14 +210,25 @@ private struct MacContent: View {
 
     private func activeTimerView(snapshot: WODTimerEngineSnapshot, totalRounds: Int) -> some View {
         VStack(spacing: DesignTokens.Spacing.lg) {
-            Text(sharedTimeString(from: timerMode == .emom ? snapshot.remainingTimeInPhase : snapshot.remainingTime))
+            // For Time counts up (floored so the shown time never runs ahead);
+            // EMOM shows the per-round countdown; Intervals the total countdown.
+            Text(sharedTimeString(from: activeDisplayTime(snapshot: snapshot)))
                 .font(.system(size: DesignTokens.Typography.Size.display, weight: DesignTokens.Typography.Weight.bold, design: .monospaced))
                 .monospacedDigit()
                 .foregroundStyle(DesignTokens.Common.Text.primary(scheme))
                 .frame(maxWidth: .infinity)
-            Text(sharedRoundLabel(snapshot: snapshot, totalRounds: totalRounds))
-                .font(.system(size: DesignTokens.Typography.Size.lg, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
-                .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+            if timerMode == .forTime {
+                // No rounds in For Time; show the cap as context when one is set.
+                if let cap = engine.forTimeCapSeconds {
+                    Text("Cap \(sharedFormatEmomLength(cap))")
+                        .font(.system(size: DesignTokens.Typography.Size.lg, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
+                        .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+                }
+            } else {
+                Text(sharedRoundLabel(snapshot: snapshot, totalRounds: totalRounds))
+                    .font(.system(size: DesignTokens.Typography.Size.lg, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
+                    .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+            }
             if timerMode == .intervals {
                 Text(snapshot.currentPhase == .work ? "Work" : "Rest")
                     .font(.system(size: DesignTokens.Typography.Size.sm, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
@@ -222,17 +238,30 @@ private struct MacContent: View {
         .transition(.opacity)
     }
 
+    private func activeDisplayTime(snapshot: WODTimerEngineSnapshot) -> TimeInterval {
+        switch timerMode {
+        case .emom: return snapshot.remainingTimeInPhase
+        case .intervals: return snapshot.remainingTime
+        case .forTime: return floor(snapshot.elapsedTime)
+        }
+    }
+
     private func idleSettingsView(state: WODTimerEngineState) -> some View {
         // Render only the active mode's steppers. Overlaying both in a ZStack made
         // EMOM reserve height for Intervals' 3rd stepper, leaving an empty gap.
         VStack(spacing: DesignTokens.Spacing.lg) {
-            if timerMode == .emom {
+            switch timerMode {
+            case .emom:
                 SharedStepperView(value: $rounds, range: roundsRange, label: "Rounds", onChange: { syncEngineIfIdle(state) }, theme: Self.macStepperTheme, useLongPressRepeat: true)
                 SharedStepperView(value: $emomRoundLength, range: emomLengthRange, step: 30, displayString: sharedFormatEmomLength(emomRoundLength), label: "Round length", onChange: { syncEngineIfIdle(state) }, theme: Self.macStepperTheme, useLongPressRepeat: true)
-            } else {
+            case .intervals:
                 SharedStepperView(value: $intervalsWork, range: intervalsWorkRange, label: "Work (sec)", onChange: { syncEngineIfIdle(state) }, theme: Self.macStepperTheme, useLongPressRepeat: true)
                 SharedStepperView(value: $intervalsRest, range: intervalsRestRange, label: "Rest (sec)", onChange: { syncEngineIfIdle(state) }, theme: Self.macStepperTheme, useLongPressRepeat: true)
                 SharedStepperView(value: $intervalsRounds, range: intervalsRoundsRange, label: "Rounds", onChange: { syncEngineIfIdle(state) }, theme: Self.macStepperTheme, useLongPressRepeat: true)
+            case .forTime:
+                // Single stepper covers both "no cap" and the cap value: the 0
+                // sentinel renders as "No cap" and steps to 0:30, 1:00, … 60:00.
+                SharedStepperView(value: $forTimeCap, range: forTimeCapRange, step: forTimeCapStep, displayString: forTimeCapDisplay(forTimeCap), label: "Time cap", onChange: { syncEngineIfIdle(state) }, theme: Self.macStepperTheme, useLongPressRepeat: true)
             }
         }
         .animation(.easeInOut(duration: 0.25), value: timerMode)
@@ -298,13 +327,19 @@ private struct MacContent: View {
         switch timerMode {
         case .emom: return "Select the number of rounds, and length of each round."
         case .intervals: return "Set work time, rest time, and number of rounds."
+        case .forTime: return "The clock counts up. Press Stop when you finish, or set an optional time cap."
         }
     }
 
     private func macPrimaryButton(snapshot: WODTimerEngineSnapshot, now: Date) -> some View {
         let (title, action): (String, () -> Void) = switch snapshot.state {
         case .idle: ("Start", { countdownEndTime = now.addingTimeInterval(10) })
-        case .running: ("Pause", { var e = engine; e.pause(now: now); engine = e })
+        case .running:
+            // For Time: the clock runs until you stop it. Stop freezes the final
+            // time via finish(now:); Cancel below still discards.
+            timerMode == .forTime
+                ? ("Stop", { var e = engine; e.finish(now: now); engine = e })
+                : ("Pause", { var e = engine; e.pause(now: now); engine = e })
         case .paused: ("Resume", { var e = engine; e.resume(now: now); engine = e })
         case .finished: ("Reset", { var e = engine; e.reset(); engine = e })
         }
@@ -320,6 +355,8 @@ private struct MacContent: View {
             engine = WODTimerEngine(emomRounds: rounds, secondsPerRound: emomRoundLength)
         case .intervals:
             engine = WODTimerEngine(workSeconds: intervalsWork, restSeconds: intervalsRest, rounds: intervalsRounds)
+        case .forTime:
+            engine = WODTimerEngine(forTimeCapSeconds: forTimeEngineCap(forTimeCap))
         }
     }
 

--- a/WODrounds/tvOSContentView.swift
+++ b/WODrounds/tvOSContentView.swift
@@ -339,6 +339,8 @@ struct ContentView: View {
     /// In-round audio cues. See `iOSContentView.checkInRoundCues` for full doc.
     private func checkInRoundCues(now: Date) {
         guard engine.state == .running else { return }
+        // For Time counts up with no rounds/phases — none of the in-round cues apply.
+        if case .forTime = engine.mode { return }
         let snapshot = engine.snapshot(now: now)
         let remaining = snapshot.remainingTimeInPhase
         let round = snapshot.currentRound
@@ -350,6 +352,8 @@ struct ContentView: View {
                 return TimeInterval(spr)
             case .intervals(let w, let r, _):
                 return TimeInterval(phase == .work ? w : r)
+            case .forTime:
+                return 0 // unreachable (guarded above); keeps the switch exhaustive
             }
         }()
 

--- a/WODrounds/tvOSContentView.swift
+++ b/WODrounds/tvOSContentView.swift
@@ -26,6 +26,8 @@ struct ContentView: View {
     @State private var intervalsRounds: Int = 8
     @State private var engine = WODTimerEngine(emomRounds: 10, secondsPerRound: 60)
     @AppStorage("emomRoundLengthSeconds") private var emomRoundLengthSeconds: Int = 60
+    // For Time cap; 0 = "No cap" sentinel (see forTimeCapRange).
+    @AppStorage("forTimeCapSeconds") private var forTimeCapSeconds: Int = 0
     @State private var showCancelConfirmation = false
     @State private var showAbout = false
     @State private var countdownEndTime: Date? = nil
@@ -182,7 +184,8 @@ struct ContentView: View {
             Spacer()
 
             if snapshot.state == .finished {
-                SharedDoneView(totalRounds: totalRounds, theme: Self.tvOSDoneTheme)
+                SharedDoneView(totalRounds: totalRounds, theme: Self.tvOSDoneTheme,
+                               finishedTime: timerMode == .forTime ? snapshot.elapsedTime : nil)
                     .transition(.opacity)
             } else if snapshot.state == .running || snapshot.state == .paused {
                 tvOSActiveTimerView(snapshot: snapshot, totalRounds: totalRounds)
@@ -224,14 +227,25 @@ struct ContentView: View {
 
     private func tvOSActiveTimerView(snapshot: WODTimerEngineSnapshot, totalRounds: Int) -> some View {
         VStack(spacing: DesignTokens.Spacing.lg) {
-            Text(sharedTimeString(from: timerMode == .emom ? snapshot.remainingTimeInPhase : snapshot.remainingTime))
+            // For Time counts up (floored so the shown time never runs ahead);
+            // EMOM shows the per-round countdown; Intervals the total countdown.
+            Text(sharedTimeString(from: tvOSActiveDisplayTime(snapshot: snapshot)))
                 .font(.system(size: TVOSTypography.display, weight: DesignTokens.Typography.Weight.bold, design: .monospaced))
                 .monospacedDigit()
                 .foregroundStyle(DesignTokens.Common.Text.primary(scheme))
                 .frame(maxWidth: .infinity)
-            Text(sharedRoundLabel(snapshot: snapshot, totalRounds: totalRounds))
-                .font(.system(size: TVOSTypography.lg, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
-                .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+            if timerMode == .forTime {
+                // No rounds in For Time; show the cap as context when one is set.
+                if let cap = engine.forTimeCapSeconds {
+                    Text("Cap \(sharedFormatEmomLength(cap))")
+                        .font(.system(size: TVOSTypography.lg, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
+                        .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+                }
+            } else {
+                Text(sharedRoundLabel(snapshot: snapshot, totalRounds: totalRounds))
+                    .font(.system(size: TVOSTypography.lg, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
+                    .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
+            }
             if timerMode == .intervals {
                 Text(snapshot.currentPhase == .work ? "Work" : "Rest")
                     .font(.system(size: TVOSTypography.sm, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))
@@ -241,6 +255,14 @@ struct ContentView: View {
         .transition(.opacity)
     }
 
+    private func tvOSActiveDisplayTime(snapshot: WODTimerEngineSnapshot) -> TimeInterval {
+        switch timerMode {
+        case .emom: return snapshot.remainingTimeInPhase
+        case .intervals: return snapshot.remainingTime
+        case .forTime: return floor(snapshot.elapsedTime)
+        }
+    }
+
     private func tvOSIdleSettingsView(state: WODTimerEngineState) -> some View {
         // Render only the active mode's steppers. The previous ZStack overlay kept
         // the inactive mode's steppers in the view at opacity 0 — but opacity /
@@ -248,13 +270,18 @@ struct ContentView: View {
         // focus engine, so the Siri Remote could move focus into invisible buttons
         // and get stuck. Conditional rendering removes them entirely.
         VStack(spacing: DesignTokens.Spacing.xl) {
-            if timerMode == .emom {
+            switch timerMode {
+            case .emom:
                 SharedStepperView(value: $rounds, range: roundsRange, label: "Rounds", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
                 SharedStepperView(value: $emomRoundLengthSeconds, range: emomLengthRange, step: 30, displayString: sharedFormatEmomLength(emomRoundLengthSeconds), label: "Round length", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
-            } else {
+            case .intervals:
                 SharedStepperView(value: $intervalsWork, range: intervalsWorkRange, label: "Work (sec)", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
                 SharedStepperView(value: $intervalsRest, range: intervalsRestRange, label: "Rest (sec)", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
                 SharedStepperView(value: $intervalsRounds, range: intervalsRoundsRange, label: "Rounds", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
+            case .forTime:
+                // Single stepper covers both "no cap" and the cap value: the 0
+                // sentinel renders as "No cap" and steps to 0:30, 1:00, … 60:00.
+                SharedStepperView(value: $forTimeCapSeconds, range: forTimeCapRange, step: forTimeCapStep, displayString: forTimeCapDisplay(forTimeCapSeconds), label: "Time cap", onChange: { syncEngineIfIdle(state) }, theme: Self.tvOSStepperTheme, useLongPressRepeat: false)
             }
         }
         .animation(.easeInOut(duration: 0.25), value: timerMode)
@@ -403,6 +430,8 @@ struct ContentView: View {
             return "Select the number of rounds, and length of each round."
         case .intervals:
             return "Set work time, rest time, and number of rounds."
+        case .forTime:
+            return "The clock counts up. Press Stop when you finish, or set an optional time cap."
         }
     }
 
@@ -410,7 +439,12 @@ struct ContentView: View {
         let (title, action): (String, () -> Void) = switch snapshot.state {
         case .idle:
             ("Start", { countdownEndTime = now.addingTimeInterval(10) })
-        case .running: ("Pause", { var e = engine; e.pause(now: now); engine = e })
+        case .running:
+            // For Time: the clock runs until you stop it. Stop freezes the final
+            // time via finish(now:); Cancel below still discards.
+            timerMode == .forTime
+                ? ("Stop", { var e = engine; e.finish(now: now); engine = e })
+                : ("Pause", { var e = engine; e.pause(now: now); engine = e })
         case .paused: ("Resume", { var e = engine; e.resume(now: now); engine = e })
         case .finished: ("Reset", { var e = engine; e.reset(); engine = e })
         }
@@ -426,6 +460,8 @@ struct ContentView: View {
             engine = WODTimerEngine(emomRounds: rounds, secondsPerRound: emomRoundLengthSeconds)
         case .intervals:
             engine = WODTimerEngine(workSeconds: intervalsWork, restSeconds: intervalsRest, rounds: intervalsRounds)
+        case .forTime:
+            engine = WODTimerEngine(forTimeCapSeconds: forTimeEngineCap(forTimeCapSeconds))
         }
     }
 }

--- a/WODroundsTests/WODroundsTests.swift
+++ b/WODroundsTests/WODroundsTests.swift
@@ -504,4 +504,216 @@ struct WODroundsTests {
         #expect(engine.workSeconds == 0)
         #expect(engine.restSeconds == 0)
     }
+
+    // MARK: - For Time: Initialisation
+
+    @Test func forTimeCappedInit() {
+        let engine = WODTimerEngine(forTimeCapSeconds: 900)
+        #expect(engine.state == .idle)
+        #expect(engine.forTimeCapSeconds == 900)
+        #expect(engine.totalDurationSeconds == 900)
+    }
+
+    @Test func forTimeUncappedInit() {
+        let engine = WODTimerEngine(forTimeCapSeconds: nil)
+        #expect(engine.forTimeCapSeconds == nil)
+        // Deliberate: uncapped has no total. Every auto-finish comparison must skip it.
+        #expect(engine.totalDurationSeconds == 0)
+    }
+
+    @Test func forTimeCapAccessorNilForOtherModes() {
+        let engine = WODTimerEngine(emomRounds: 5, secondsPerRound: 60)
+        #expect(engine.forTimeCapSeconds == nil)
+    }
+
+    // MARK: - For Time: Uncapped runs and never auto-finishes
+
+    @Test func forTimeUncappedStartWorks() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        engine.start(now: Date())
+        #expect(engine.state == .running)
+    }
+
+    @Test func forTimeUncappedCountsUp() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let start = Date()
+        engine.start(now: start)
+        let snap = engine.snapshot(now: start.addingTimeInterval(487))
+        #expect(snap.state == .running)
+        #expect(snap.elapsedTime == 487)
+        #expect(snap.remainingTime == 0)
+    }
+
+    @Test func forTimeUncappedNeverAutoFinishesOnTick() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let start = Date()
+        engine.start(now: start)
+        engine.tick(now: start.addingTimeInterval(7200)) // two hours in
+        #expect(engine.state == .running)
+    }
+
+    @Test func forTimeUncappedPauseDoesNotFinish() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let start = Date()
+        engine.start(now: start)
+        // Regression guard: pause() compares elapsed >= total; with total == 0 that
+        // would instantly finish an uncapped workout unless short-circuited.
+        engine.pause(now: start.addingTimeInterval(90))
+        #expect(engine.state == .paused)
+        let snap = engine.snapshot(now: start.addingTimeInterval(300))
+        #expect(snap.state == .paused)
+        #expect(snap.elapsedTime == 90)
+    }
+
+    // MARK: - For Time: Capped auto-finish
+
+    @Test func forTimeCappedAutoFinishesAtCap() {
+        var engine = WODTimerEngine(forTimeCapSeconds: 600)
+        let start = Date()
+        engine.start(now: start)
+        engine.tick(now: start.addingTimeInterval(600))
+        #expect(engine.state == .finished)
+        let snap = engine.snapshot(now: start.addingTimeInterval(600))
+        #expect(snap.elapsedTime == 600) // frozen at the cap, not still growing
+    }
+
+    @Test func forTimeCappedRemainingCountsDownWhileElapsedCountsUp() {
+        var engine = WODTimerEngine(forTimeCapSeconds: 600)
+        let start = Date()
+        engine.start(now: start)
+        let snap = engine.snapshot(now: start.addingTimeInterval(240))
+        #expect(snap.state == .running)
+        #expect(snap.elapsedTime == 240)
+        #expect(snap.remainingTime == 360)
+    }
+
+    @Test func forTimeCappedSnapshotBeyondCapShowsFinished() {
+        var engine = WODTimerEngine(forTimeCapSeconds: 300)
+        let start = Date()
+        engine.start(now: start)
+        let snap = engine.snapshot(now: start.addingTimeInterval(500))
+        #expect(snap.state == .finished)
+        #expect(snap.elapsedTime == 300)
+    }
+
+    // MARK: - For Time: finish(now:) freezes elapsed
+
+    @Test func forTimeFinishFreezesElapsed() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let start = Date()
+        engine.start(now: start)
+        engine.finish(now: start.addingTimeInterval(437))
+        #expect(engine.state == .finished)
+        // Elapsed must not keep growing after Stop (Done screen + HealthKit).
+        let snap = engine.snapshot(now: start.addingTimeInterval(2000))
+        #expect(snap.state == .finished)
+        #expect(snap.elapsedTime == 437)
+    }
+
+    @Test func forTimeFinishFromPausedExcludesOpenPause() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let start = Date()
+        engine.start(now: start)
+        engine.pause(now: start.addingTimeInterval(100))
+        // Stop while paused, 50s into the pause: active time is still 100s.
+        engine.finish(now: start.addingTimeInterval(150))
+        let snap = engine.snapshot(now: start.addingTimeInterval(400))
+        #expect(snap.state == .finished)
+        #expect(snap.elapsedTime == 100)
+    }
+
+    @Test func forTimeFinishExcludesCompletedPause() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let start = Date()
+        engine.start(now: start)
+        engine.pause(now: start.addingTimeInterval(60))
+        engine.resume(now: start.addingTimeInterval(90)) // 30s pause
+        engine.finish(now: start.addingTimeInterval(200))
+        let snap = engine.snapshot(now: start.addingTimeInterval(200))
+        #expect(snap.elapsedTime == 170) // 200 - 30
+    }
+
+    @Test func forTimeFinishIsNoOpFromIdle() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        engine.finish(now: Date())
+        #expect(engine.state == .idle) // finish only acts on running/paused
+    }
+
+    @Test func forTimeResetClearsFrozenTime() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let start = Date()
+        engine.start(now: start)
+        engine.finish(now: start.addingTimeInterval(120))
+        engine.reset()
+        #expect(engine.state == .idle)
+        let snap = engine.snapshot(now: start.addingTimeInterval(300))
+        #expect(snap.elapsedTime == 0)
+    }
+
+    // MARK: - For Time: HealthKit end date
+
+    @Test func forTimeEffectiveEndDateExcludesPause() {
+        var engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let start = Date()
+        engine.start(now: start)
+        engine.pause(now: start.addingTimeInterval(120))
+        engine.resume(now: start.addingTimeInterval(180)) // 60s pause
+        let end = engine.effectiveWorkoutEndDate(now: start.addingTimeInterval(300))
+        #expect(end == start.addingTimeInterval(240)) // 300 - 60 active
+    }
+
+    // MARK: - For Time: elapsedTime present for other modes too
+
+    @Test func emomSnapshotCarriesElapsedTime() {
+        var engine = WODTimerEngine(emomRounds: 5, secondsPerRound: 60)
+        let start = Date()
+        engine.start(now: start)
+        let snap = engine.snapshot(now: start.addingTimeInterval(75))
+        #expect(snap.elapsedTime == 75)
+    }
+
+    // MARK: - For Time: Sync payload
+
+    @Test func forTimeSyncPayloadCarriesCap() {
+        var engine = WODTimerEngine(forTimeCapSeconds: 1200)
+        let start = Date()
+        engine.start(now: start)
+        let payload = engine.syncPayload(now: start)
+        #expect(payload.mode == "forTime")
+        #expect(payload.capSeconds == 1200)
+        #expect(payload.state == "running")
+    }
+
+    @Test func forTimeUncappedSyncPayloadHasNilCap() {
+        let engine = WODTimerEngine(forTimeCapSeconds: nil)
+        let payload = engine.syncPayload(now: Date())
+        #expect(payload.mode == "forTime")
+        #expect(payload.capSeconds == nil)
+    }
+
+    @Test func otherModesSyncPayloadHasNilCap() {
+        let engine = WODTimerEngine(emomRounds: 3, secondsPerRound: 60)
+        let payload = engine.syncPayload(now: Date())
+        #expect(payload.mode == "emom")
+        #expect(payload.capSeconds == nil)
+        #expect(payload.finishedAt == nil)
+    }
+
+    @Test func forTimeSyncPayloadRoundTripsThroughJSON() throws {
+        var engine = WODTimerEngine(forTimeCapSeconds: 900)
+        let start = Date()
+        engine.start(now: start)
+        engine.finish(now: start.addingTimeInterval(300))
+        let payload = engine.syncPayload(now: start.addingTimeInterval(300))
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let data = try encoder.encode(payload)
+        let decoded = try decoder.decode(WODTimerEngine.SyncPayload.self, from: data)
+        #expect(decoded.mode == "forTime")
+        #expect(decoded.capSeconds == 900)
+        #expect(decoded.state == "finished")
+        #expect(decoded.finishedAt != nil)
+    }
 }

--- a/WODroundsUITests/WODroundsUITests.swift
+++ b/WODroundsUITests/WODroundsUITests.swift
@@ -38,27 +38,95 @@ final class WODroundsUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
-        // Dismiss the HealthKit authorization sheet if it appears on first Start.
-        addUIInterruptionMonitor(withDescription: "Health Access") { element in
-            for label in ["Allow", "Don't Allow", "Turn On All", "OK", "Dismiss"] {
-                let button = element.buttons[label]
-                if button.exists { button.tap(); return true }
-            }
-            return false
-        }
-
         let start = app.buttons["Start"]
         XCTAssertTrue(start.waitForExistence(timeout: 5), "Start button should exist on the idle screen")
         start.tap()
-        app.tap() // Nudge so the interruption monitor handles the Health sheet.
 
         // The count-in overlay must expose a Cancel button (the #38 feature).
         let cancel = app.buttons["Cancel countdown"]
-        XCTAssertTrue(cancel.waitForExistence(timeout: 8), "Count-in should show a Cancel button (#38)")
+        XCTAssertTrue(waitDismissingHealthSheet(for: cancel, timeout: 45, in: app),
+                      "Count-in should show a Cancel button (#38)")
         cancel.tap()
 
         // Cancelling the count-in returns to setup.
         XCTAssertTrue(start.waitForExistence(timeout: 5), "Cancelling the count-in should return to the setup screen")
+    }
+
+    /// End-to-end For Time flow (#15): switch to For Time → Start → count-in →
+    /// running shows Stop → Stop → Done screen shows "Finished in" → Reset returns
+    /// to setup.
+    @MainActor
+    func testForTimeStartStopShowsFinishedTime() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Switch to For Time; its setup shows the Time cap stepper.
+        let forTime = app.buttons["For Time"]
+        XCTAssertTrue(forTime.waitForExistence(timeout: 5), "Mode switch should have a For Time segment")
+        forTime.tap()
+        XCTAssertTrue(app.staticTexts["Time cap"].waitForExistence(timeout: 3), "For Time setup should show the Time cap stepper")
+
+        let start = app.buttons["Start"]
+        XCTAssertTrue(start.waitForExistence(timeout: 5))
+        start.tap()
+
+        // After the 10s count-in, a running For Time shows Stop (not Pause).
+        let stop = app.buttons["Stop"]
+        XCTAssertTrue(waitDismissingHealthSheet(for: stop, timeout: 45, in: app),
+                      "Running For Time should show a Stop button")
+        XCTAssertFalse(app.buttons["Pause"].exists, "For Time must not offer Pause while running")
+
+        // Let a couple of seconds elapse, then stop and expect the finished time.
+        sleep(2)
+        stop.tap()
+        // SharedDoneView combines its children into one accessibility element, so
+        // "Finished in …" is part of a combined label, not a standalone staticText.
+        let finished = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label CONTAINS 'Finished in'")).firstMatch
+        XCTAssertTrue(finished.waitForExistence(timeout: 5), "Done screen should show 'Finished in MM:SS' for For Time")
+
+        // Reset returns to setup.
+        let reset = app.buttons["Reset"]
+        XCTAssertTrue(reset.waitForExistence(timeout: 5))
+        reset.tap()
+        XCTAssertTrue(start.waitForExistence(timeout: 5), "Reset should return to the setup screen")
+    }
+
+    /// Waits for `element`, dismissing the HealthKit authorization sheet whenever
+    /// it shows up along the way. The sheet is hosted by a remote process and its
+    /// appearance time varies wildly (slow on a freshly-booted simulator), and
+    /// interruption monitors only fire on interactions — waitForExistence never
+    /// triggers them — so a fixed pre-wait either wastes the count-in window or
+    /// misses a late sheet. Polling for the target and swatting the sheet by its
+    /// locale-independent identifier (labels are localized, e.g. "Tillad ikke")
+    /// handles both orders. The budget is generous because on a fresh simulator
+    /// the HealthKit authorization *completion* can arrive 20-30s after the sheet
+    /// is dismissed, and the count-in only starts once it fires; the loop returns
+    /// as soon as the target exists, so the extra budget costs nothing when fast.
+    @MainActor
+    @discardableResult
+    private func waitDismissingHealthSheet(for element: XCUIElement, timeout: TimeInterval, in app: XCUIApplication) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        let deny = app.buttons["UIA.Health.AuthSheet.CancelButton"]
+        // On a completely fresh device, denying pops a confirmation alert on top
+        // ("you can enable categories later in Health"); authorization does not
+        // complete (and the count-in never starts) until its OK is tapped.
+        let confirmOK = app.alerts.buttons["OK"]
+        // Tap deny at most once: the first tap dismisses the sheet, and a second
+        // tap attempt races its dismissal (exists → true, then tap() re-resolves
+        // against a gone element and fails the test).
+        var deniedOnce = false
+        while Date() < deadline {
+            if confirmOK.exists {
+                confirmOK.tap()
+            } else if !deniedOnce, deny.exists {
+                deniedOnce = true
+                deny.tap()
+            }
+            if element.exists { return true }
+            usleep(300_000) // 0.3s between polls
+        }
+        return element.exists
     }
 
     @MainActor

--- a/WODroundsWatch/WODTimerSync.swift
+++ b/WODroundsWatch/WODTimerSync.swift
@@ -14,12 +14,17 @@ struct WODTimerSyncPayload: Codable {
     let startDate: Date?
     let accumulatedPauseDuration: TimeInterval
     let pausedAt: Date?
-    let mode: String
+    let mode: String        // "emom" | "intervals" | "forTime"
     let totalMinutes: Int
     let emomSecondsPerRound: Int?
     let workSeconds: Int?
     let restSeconds: Int?
     let rounds: Int?
+    /// For Time cap; nil when uncapped or in another mode. Optional so payloads
+    /// from older iPhone app versions still decode.
+    let capSeconds: Int?
+    /// When the iPhone froze the workout via finish(now:); freezes elapsed here too.
+    let finishedAt: Date?
     let lastUpdated: Date
 }
 
@@ -49,6 +54,8 @@ enum WODTimerSync {
         case "intervals":
             guard let w = payload.workSeconds, let r = payload.restSeconds, let n = payload.rounds, n > 0 else { return 0 }
             return TimeInterval(n) * TimeInterval(w) + TimeInterval(n - 1) * TimeInterval(r)
+        case "forTime":
+            return TimeInterval(payload.capSeconds ?? 0) // 0 = uncapped (no total)
         default:
             return 0
         }
@@ -63,6 +70,9 @@ enum WODTimerSync {
     struct SyncedSnapshot {
         let state: WODTimerEngineState
         let remainingTime: TimeInterval
+        /// Seconds elapsed since start, excluding pauses; frozen once finished.
+        /// The headline value for a synced For Time workout (count-up display).
+        let elapsedTime: TimeInterval
         let currentRound: Int
         let totalRounds: Int
         let remainingTimeInPhase: TimeInterval
@@ -72,15 +82,29 @@ enum WODTimerSync {
         switch payload.state {
         case "idle":
             let total = payload.mode == "emom" ? payload.totalMinutes : (payload.rounds ?? 0)
-            return SyncedSnapshot(state: .idle, remainingTime: 0, currentRound: 0, totalRounds: max(1, total), remainingTimeInPhase: 0)
+            return SyncedSnapshot(state: .idle, remainingTime: 0, elapsedTime: 0, currentRound: 0, totalRounds: max(1, total), remainingTimeInPhase: 0)
         case "finished":
             let total = payload.mode == "emom" ? payload.totalMinutes : (payload.rounds ?? 0)
-            return SyncedSnapshot(state: .finished, remainingTime: 0, currentRound: max(1, total), totalRounds: max(1, total), remainingTimeInPhase: 0)
+            // Frozen elapsed: finishedAt (explicit Stop) beats the mode total, so a
+            // stopped For Time shows the real final time instead of growing/zero.
+            let frozenElapsed: TimeInterval
+            if let finishedAt = payload.finishedAt, let start = payload.startDate {
+                frozenElapsed = max(0, finishedAt.timeIntervalSince(start) - payload.accumulatedPauseDuration)
+            } else {
+                frozenElapsed = totalDurationSeconds(payload: payload)
+            }
+            return SyncedSnapshot(state: .finished, remainingTime: 0, elapsedTime: frozenElapsed, currentRound: max(1, total), totalRounds: max(1, total), remainingTimeInPhase: 0)
         case "running", "paused":
             guard payload.startDate != nil else { return nil }
             let totalSec = totalDurationSeconds(payload: payload)
             let elapsed = elapsedSeconds(payload: payload, now: now)
             let remaining = max(0, totalSec - elapsed)
+            let state: WODTimerEngineState = payload.state == "running" ? .running : .paused
+            if payload.mode == "forTime" {
+                // Count-up; no rounds. Uncapped (cap nil → totalSec 0) never finishes
+                // on its own — the iPhone drives the finished state.
+                return SyncedSnapshot(state: state, remainingTime: remaining, elapsedTime: elapsed, currentRound: 1, totalRounds: 1, remainingTimeInPhase: remaining)
+            }
             let totalRounds: Int = payload.mode == "emom" ? payload.totalMinutes : (payload.rounds ?? 1)
             let round: Int
             let remainingTimeInPhase: TimeInterval
@@ -95,8 +119,7 @@ enum WODTimerSync {
                 round = totalSec <= 0 ? n : min(Int(elapsed / cycle), n - 1) + 1
                 remainingTimeInPhase = 0
             }
-            let state: WODTimerEngineState = payload.state == "running" ? .running : .paused
-            return SyncedSnapshot(state: state, remainingTime: remaining, currentRound: round, totalRounds: totalRounds, remainingTimeInPhase: remainingTimeInPhase)
+            return SyncedSnapshot(state: state, remainingTime: remaining, elapsedTime: elapsed, currentRound: round, totalRounds: totalRounds, remainingTimeInPhase: remainingTimeInPhase)
         default:
             return nil
         }

--- a/WODroundsWatch/WatchContentView.swift
+++ b/WODroundsWatch/WatchContentView.swift
@@ -33,9 +33,17 @@ struct WatchContentView: View {
             let syncedPayload = sessionManager.receivedPayload
             let syncedSnapshot = syncedPayload.flatMap { WODTimerSync.snapshot(from: $0, now: now) }
             let useSynced = syncedSnapshot.map { $0.state == .running || $0.state == .paused } ?? false
+            // Synced For Time counts up and has no rounds (Watch only follows iPhone
+            // For Time; there is no local For Time mode on the Watch).
+            let isSyncedForTime = useSynced && syncedPayload?.mode == "forTime"
             let (displayTime, currentRound, totalRounds, state): (TimeInterval, Int, Int, WODTimerEngineState) = {
                 if useSynced, let s = syncedSnapshot, let payload = syncedPayload {
-                    let disp = payload.mode == "emom" ? s.remainingTimeInPhase : s.remainingTime
+                    let disp: TimeInterval
+                    switch payload.mode {
+                    case "emom": disp = s.remainingTimeInPhase
+                    case "forTime": disp = s.elapsedTime
+                    default: disp = s.remainingTime
+                    }
                     return (disp, s.currentRound, s.totalRounds, s.state)
                 }
                 let local = engine.snapshot(now: now)
@@ -59,14 +67,18 @@ struct WatchContentView: View {
                             .foregroundStyle(WatchDesign.Colors.textTertiary(colorScheme))
                     }
 
-                    Text(timeString(from: displayTime))
+                    // Count-up (For Time) floors so the shown time never runs ahead;
+                    // count-down keeps ceiling so 0 is only shown when truly done.
+                    Text(timeString(from: isSyncedForTime ? floor(displayTime) : displayTime))
                         .font(.system(size: WatchDesign.timerFontSize, weight: .bold, design: .rounded))
                         .monospacedDigit()
                         .foregroundStyle(WatchDesign.Colors.textPrimary(colorScheme))
 
-                    Text("R \(currentRound)/\(totalRounds)")
-                        .font(.system(size: WatchDesign.roundFontSize, weight: .semibold, design: .rounded))
-                        .foregroundStyle(WatchDesign.Colors.textSecondary(colorScheme))
+                    if !isSyncedForTime {
+                        Text("R \(currentRound)/\(totalRounds)")
+                            .font(.system(size: WatchDesign.roundFontSize, weight: .semibold, design: .rounded))
+                            .foregroundStyle(WatchDesign.Colors.textSecondary(colorScheme))
+                    }
 
                     if useSynced {
                         Text("Following iPhone", bundle: .main)

--- a/docs/APP_STORE_CONNECT.md
+++ b/docs/APP_STORE_CONNECT.md
@@ -37,10 +37,11 @@ Interval & workout timer for EMOM, Tabata, HIIT. Start on iPhone, follow on Appl
 **First 2–3 lines** are often shown in search results and previews — make sure they contain key terms (interval timer, workout, EMOM, CrossFit). Then add concrete bullets.
 
 ```
-Interval timer and workout timer for EMOM, CrossFit, and HIIT. No accounts, no sign-up. Just time, rounds, and focus.
+Interval timer and workout timer for EMOM, For Time, CrossFit, and HIIT. No accounts, no sign-up. Just time, rounds, and focus.
 
 • EMOM: Set rounds (1–120) and round length (0:30–9:30). Start, pause, resume, reset.
 • Intervals: Work, rest, rounds. Perfect for Tabata (20/10 × 8) and any interval workout.
+• For Time: The clock counts up. Press Stop when you finish and your time is saved, or set an optional time cap.
 • Apple Watch: Start on iPhone – watch shows same time and round. Or run the timer on the watch only.
 • Audio cues: "Get ready", halfway and ten-seconds voice cues, a 3-2-1 countdown, rounds remaining (10, 5, 2), and randomized completion sounds.
 • Large type, one-handed use, runs in background. Light and dark theme.
@@ -53,16 +54,16 @@ The simplest WOD timer: no database, no sharing. Just timer and rounds.
 
 ## What's New in This Version (release notes)
 
-Update per release. Current — **1.4**:
+Update per release. Current — **1.5**:
 
 ```
-• Cancel the countdown before a workout starts — tapped Start by mistake? Just back out.
-• More accurate workout duration in Apple Health: paused time no longer counts as active.
-• Fixed a doubled voice announcement during interval workouts.
+• New: For Time mode. The clock counts up from zero; press Stop when you finish and your time is saved.
+• Set an optional time cap and the For Time clock stops there automatically.
+• Your Apple Watch follows a For Time workout when you start on iPhone.
 • Small fixes and polish throughout.
 ```
 
-Mac variant (drop the Health line; add the layout note): "Cancel the countdown before a workout starts. · Tidier setup screen. · Small fixes and polish." tvOS variant: "Cancel the countdown before a workout starts. · Smoother remote navigation with a calmer focus highlight. · Small fixes and polish."
+Mac variant (drop the Watch line): "New: For Time mode. The clock counts up; press Stop when you finish, or set an optional time cap. · Small fixes and polish." tvOS variant: same as Mac.
 
 ---
 
@@ -170,10 +171,11 @@ EMOM and Intervals timer on your Mac. Same app as on iPhone and Watch – no sig
 ## Description (required)
 
 ```
-Interval timer and workout timer for EMOM, CrossFit, and HIIT on Mac. No accounts, no sign-up. Just time, rounds, and focus.
+Interval timer and workout timer for EMOM, For Time, CrossFit, and HIIT on Mac. No accounts, no sign-up. Just time, rounds, and focus.
 
 • EMOM: Set rounds (1–120) and round length (0:30–9:30). Start, pause, resume, reset.
 • Intervals: Work, rest, rounds. Perfect for Tabata (20/10 × 8) and any interval workout.
+• For Time: The clock counts up. Press Stop when you finish and your time is saved, or set an optional time cap.
 • Compact window, large type. Runs in background. Light and dark theme.
 • One-time purchase: pay once, own it forever. No subscription, no ads, no in-app purchases.
 
@@ -213,10 +215,11 @@ EMOM and Intervals timer on the big screen. Use your Apple TV remote to start, p
 ## Description (required)
 
 ```
-Interval timer and workout timer for EMOM, CrossFit, and HIIT on Apple TV. No accounts, no sign-up. Just time, rounds, and focus.
+Interval timer and workout timer for EMOM, For Time, CrossFit, and HIIT on Apple TV. No accounts, no sign-up. Just time, rounds, and focus.
 
 • EMOM: Set rounds (1–120) and round length (0:30–9:30). Start, pause, resume, reset with the remote.
 • Intervals: Work, rest, rounds. Perfect for Tabata (20/10 × 8) and any interval workout.
+• For Time: The clock counts up. Press Stop when you finish and your time is saved, or set an optional time cap.
 • Large type for the living room. Focus-friendly UI. Light and dark theme.
 • One-time purchase: pay once, own it forever. No subscription, no ads, no in-app purchases.
 
@@ -254,10 +257,11 @@ Temporizador de intervalos para EMOM, Tabata y HIIT. Empieza en el iPhone y sigu
 ## Description
 
 ```
-Temporizador de intervalos y de entrenamiento para EMOM, CrossFit y HIIT. Sin cuentas, sin registro. Solo tiempo, rondas y enfoque.
+Temporizador de intervalos y de entrenamiento para EMOM, For Time, CrossFit y HIIT. Sin cuentas, sin registro. Solo tiempo, rondas y enfoque.
 
 • EMOM: define las rondas (1–120) y la duración de cada ronda (0:30–9:30). Inicia, pausa, reanuda y reinicia.
 • Intervalos: trabajo, descanso y rondas. Perfecto para Tabata (20/10 × 8) y cualquier entrenamiento por intervalos.
+• For Time: el reloj cuenta hacia arriba. Pulsa Detener al terminar y tu tiempo queda guardado, o define un límite de tiempo opcional.
 • Apple Watch: empieza en el iPhone y el reloj muestra el mismo tiempo y ronda. O usa el temporizador solo en el reloj.
 • Señales de audio: "Get ready", avisos de voz a la mitad y a los diez segundos, cuenta 3-2-1, rondas restantes (10, 5, 2) y sonidos de finalización aleatorios.
 • Texto grande, uso con una mano, funciona en segundo plano. Tema claro y oscuro.
@@ -274,12 +278,12 @@ Single words, comma-separated, no spaces; excludes terms already in the subtitle
 intervalos,entrenamiento,EMOM,CrossFit,gimnasio,cronómetro,cuenta,regresiva,WOD,rondas,ejercicio
 ```
 
-## What's New in This Version (1.4)
+## What's New in This Version (1.5)
 
 ```
-• Cancela la cuenta regresiva antes de empezar: ¿pulsaste Iniciar sin querer? Solo retrocede.
-• Duración del entrenamiento más precisa en la app Salud: el tiempo en pausa ya no cuenta como activo.
-• Se corrigió un anuncio de voz duplicado durante los entrenamientos por intervalos.
+• Nuevo: modo For Time. El reloj cuenta desde cero; pulsa Detener al terminar y tu tiempo queda guardado.
+• Define un límite de tiempo opcional y el reloj se detiene ahí automáticamente.
+• Tu Apple Watch sigue el entrenamiento For Time cuando empiezas en el iPhone.
 • Pequeñas correcciones y mejoras.
 ```
 


### PR DESCRIPTION
Closes #15. The 1.5 flagship feature: a third timer mode, **For Time**, on iPhone, iPad, Mac and Apple TV, with Apple Watch following along.

## What

**Engine** (`Shared/WODTimerEngine.swift`)
- New `WODTimerMode.forTime(capSeconds: Int?)` — nil is uncapped. The cap is modeled as an optional finish bound; EMOM/Intervals are untouched.
- Snapshot gains `elapsedTime` (the count-up headline). Uncapped has `totalDurationSeconds == 0`, so every `elapsed >= total` auto-finish comparison (snapshot, tick, and the `pause()` landmine) is short-circuited; capped auto-finishes exactly at the cap.
- New `finish(now:)` freezes the final time via `finishedAt` (folding in an open pause), so the Done screen and HealthKit duration stop growing after Stop.
- Sync payload gains optional `capSeconds`/`finishedAt` (old payloads still decode).

**UI (iOS / macOS / tvOS)**
- Third mode-switch segment. Setup is a single "Time cap" stepper: the 0 sentinel reads "No cap" and steps to 0:30…60:00 in 30s steps — one control instead of toggle + stepper, reusing the focus-safe stepper on tvOS.
- Running: clock counts up (floored), no round label, "Cap MM:SS" as context when set. Primary button is **Stop** (a For Time clock isn't paused; Cancel still discards).
- Done screen shows "Finished in MM:SS". In-round audio cues stay silent for For Time; completion sound plays. HealthKit saves the real active time.

**Watch**
- Payload mirror + explicit forTime branch (an unknown mode previously fell through to nil and dropped the Watch to its local timer mid-sync). Elapsed counts up on the wrist, no round label. Watch only follows iPhone For Time.

**Docs & version**
- CHANGELOG 1.5 entry, README, CLAUDE.md, App Store copy (EN + es-MX incl. What's New) with the queued #64 fixes. `MARKETING_VERSION 1.5`, build 13.
- **Deliberately not here:** marketing-site (`docs/*.html`) updates — the site deploys live from `main`, so For Time goes on the site in a follow-up PR on release day.

## Verification
- 69 unit tests pass (about 20 new: uncapped never auto-finishes incl. the pause() total==0 landmine, capped auto-finish at cap, finish() freezing with pauses excluded, HealthKit end date, payload round-trips).
- New end-to-end UI test: switch to For Time → Start → count-in → Stop → "Finished in MM:SS" → Reset.
- macOS, tvOS and Watch destinations build.

## After merge
1. Archive + upload builds, TestFlight on real hardware (esp. Watch sync and tvOS focus around the new stepper).
2. Submit 1.5 with the updated description (closes #64 at that point).
3. Merge the release-day site PR when approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)