### PR TITLE
CHANGELOG: record actual 1.5 build numbers per platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable user-facing changes to WODrounds. Newest first.
 
-## 1.5 (build 14)
+## 1.5 (build 13 on iOS; build 14 on macOS/tvOS)
 
 **What's New (App Store copy):**
 


### PR DESCRIPTION
iOS shipped as build 13; macOS/tvOS as build 14 (ASC had consumed 13 across the app record). One-line accuracy fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)