### PR TITLE
ci: skip Swift tests + CodeQL on docs-only changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,15 @@ name: CodeQL
 on:
   pull_request:
     branches: [main]
+    # Skip the ~30 min Swift analysis when a PR touches only docs / markdown /
+    # GitHub templates — there is no code to scan. The weekly scheduled scan
+    # still covers the whole codebase regardless.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'LICENSE'
   schedule:
     - cron: '20 14 * * 3'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,24 @@
 name: Tests
 
 on:
+  # Skip when a change touches only docs / marketing site / markdown / GitHub
+  # templates — there is no Swift to test there (docs.yml covers the site).
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'LICENSE'
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/docs/about.html
+++ b/docs/about.html
@@ -109,8 +109,8 @@
           <li>Permission to track my behavior across the web</li>
           <li>A pop-up asking for a 5-star review mid-WOD</li>
         </ul>
-        <p>I just wanted a timer. So I built one. WODrounds does EMOM and intervals. Nothing else. Press start, train, done. No friction.</p>
-        <p>The constraint that mattered most: not letting scope creep. I could add AMRAP, For Time, calendar integration, workout libraries, social features. I won't. The wedge is "minimal, private, Apple-first" and adding features weakens that.</p>
+        <p>I just wanted a timer. So I built one. WODrounds does EMOM, intervals and For Time. Nothing else. Press start, train, done. No friction.</p>
+        <p>The constraint that mattered most: not letting scope creep. For Time earned its place because it is still just a clock, one of the three ways CrossFitters actually time a workout. Things like AMRAP, calendar integration, workout libraries and social features I could add too. I won't. The wedge is "minimal, private, Apple-first" and adding features weakens that.</p>
 
         <h2>How it's made</h2>
         <p>Technical principles I stick to:</p>
@@ -128,7 +128,7 @@
 
         <h2>What I do and don't promise</h2>
         <p><strong>I promise:</strong> WODrounds is a one-time purchase — pay once and own it forever. No ads, no subscription, no in-app purchases, no upsells. The features will stay narrow. Updates will respect your time — no notification spam, no "what's new" dialogs in the way of starting a workout.</p>
-        <p><strong>I don't promise:</strong> Android support, web version, AMRAP/For Time modes, workout libraries, or social features. If those matter to you, <a href="best-crossfit-timer-apps.html">other apps</a> handle them well.</p>
+        <p><strong>I don't promise:</strong> Android support, web version, AMRAP mode, workout libraries, or social features. If those matter to you, <a href="best-crossfit-timer-apps.html">other apps</a> handle them well.</p>
 
         <h2>How to reach me</h2>
         <ul>

--- a/docs/apple-watch-timer.html
+++ b/docs/apple-watch-timer.html
@@ -225,10 +225,17 @@
             </a>
           </li>
           <li class="feature">
+            <a href="for-time-timer.html" style="text-decoration:none;color:inherit">
+              <span class="feature-icon" aria-hidden="true">For Time</span>
+              <h3>For Time Timer &rarr;</h3>
+              <p>Count up from zero and race the clock, with an optional time cap. For classic For Time WODs.</p>
+            </a>
+          </li>
+          <li class="feature">
             <a href="guide.html" style="text-decoration:none;color:inherit">
               <span class="feature-icon" aria-hidden="true">Guide</span>
               <h3>Timer Guide &rarr;</h3>
-              <p>Learn when to use EMOM vs. intervals vs. Tabata and how to set up each format.</p>
+              <p>Learn when to use EMOM vs. intervals vs. Tabata vs. For Time and how to set up each format.</p>
             </a>
           </li>
         </ul>

--- a/docs/best-crossfit-timer-apps.html
+++ b/docs/best-crossfit-timer-apps.html
@@ -154,13 +154,14 @@
           <div class="workout-card">
             <h2>WODrounds</h2>
             <p><strong>Best for:</strong> athletes who want a minimal, private timer across all Apple devices.</p>
-            <p>This is my app. I built WODrounds because I wanted a timer that does two things well: EMOM (1–120 rounds, 0:30–9:30 round length) and intervals (work 5–300s, rest 0–180s, 1–60 rounds). No accounts, no ads, no subscription, no in-app purchases. No marketing trackers in the app; optional crash reporting on iOS via Sentry. It runs natively on 5 Apple platforms: iPhone, iPad, Apple Watch, Mac and Apple TV. Start a workout on iPhone and the Watch syncs automatically via WatchConnectivity. Completed workouts are saved to Apple Health as HIIT sessions.</p>
+            <p>This is my app. I built WODrounds because I wanted a timer that does the essentials well: EMOM (1–120 rounds, 0:30–9:30 round length), intervals (work 5–300s, rest 0–180s, 1–60 rounds), and <a href="for-time-timer.html">For Time</a> (count up, optional cap). No accounts, no ads, no subscription, no in-app purchases. No marketing trackers in the app; optional crash reporting on iOS via Sentry. It runs natively on 5 Apple platforms: iPhone, iPad, Apple Watch, Mac and Apple TV. Start a workout on iPhone and the Watch syncs automatically via WatchConnectivity. Completed workouts are saved to Apple Health as HIIT sessions.</p>
             <ul>
+              <li>EMOM, Intervals and For Time (count up with an optional cap)</li>
               <li>Native on every Apple platform (including Apple TV and Mac)</li>
               <li>Real-time iPhone &rarr; Apple Watch sync</li>
               <li>No account, no ads, no subscription — see <a href="privacy.html">Privacy</a> for iOS crash reporting (Sentry) and site analytics (Umami)</li>
               <li>Apple Health integration (workouts saved as HIIT)</li>
-              <li>Does <em>not</em> support AMRAP or For Time modes</li>
+              <li>Does <em>not</em> support AMRAP mode</li>
               <li>Apple only (no Android or web version)</li>
             </ul>
           </div>
@@ -195,7 +196,14 @@
                 <td style="padding:0.5rem">&#10003;</td>
               </tr>
               <tr style="border-bottom:1px solid var(--border)">
-                <td style="padding:0.5rem 1rem">AMRAP / For Time</td>
+                <td style="padding:0.5rem 1rem">For Time</td>
+                <td style="padding:0.5rem">&#10003;</td>
+                <td style="padding:0.5rem">—</td>
+                <td style="padding:0.5rem">—</td>
+                <td style="padding:0.5rem">&#10003;</td>
+              </tr>
+              <tr style="border-bottom:1px solid var(--border)">
+                <td style="padding:0.5rem 1rem">AMRAP</td>
                 <td style="padding:0.5rem">&#10003;</td>
                 <td style="padding:0.5rem">—</td>
                 <td style="padding:0.5rem">—</td>
@@ -255,8 +263,8 @@
         </div>
 
         <h2>Which one should you pick?</h2>
-        <p>If you need AMRAP and For Time modes, <strong>SmartWOD</strong> is the most complete option. If you want maximum customization and complex interval chains, <strong>Seconds</strong> gives you the most control. If you want a free, no-frills gym clock, <strong>Box Timer</strong> works in any browser.</p>
-        <p>If you train on Apple devices, want a timer that works on your Watch, Mac and Apple TV without accounts or ads, and you primarily do EMOM and interval workouts — that is exactly what I built <strong><a href="index.html">WODrounds</a></strong> for.</p>
+        <p>If you need AMRAP as well, <strong>SmartWOD</strong> is the most complete option. If you want maximum customization and complex interval chains, <strong>Seconds</strong> gives you the most control. If you want a free, no-frills gym clock, <strong>Box Timer</strong> works in any browser.</p>
+        <p>If you train on Apple devices, want a timer that works on your Watch, Mac and Apple TV without accounts or ads, and you do EMOM, interval and <a href="for-time-timer.html">For Time</a> workouts, that is exactly what I built <strong><a href="index.html">WODrounds</a></strong> for.</p>
 
         <p class="guide-cta"><a href="https://apps.apple.com/app/wodrounds/id6759229877" class="btn btn-primary btn-large">Try WODrounds</a></p>
 

--- a/docs/emom-timer.html
+++ b/docs/emom-timer.html
@@ -244,10 +244,17 @@
             </a>
           </li>
           <li class="feature">
+            <a href="for-time-timer.html" style="text-decoration:none;color:inherit">
+              <span class="feature-icon" aria-hidden="true">For Time</span>
+              <h3>For Time Timer &rarr;</h3>
+              <p>Count up from zero and race the clock, with an optional time cap. For classic For Time WODs.</p>
+            </a>
+          </li>
+          <li class="feature">
             <a href="guide.html" style="text-decoration:none;color:inherit">
               <span class="feature-icon" aria-hidden="true">Guide</span>
               <h3>Timer Guide &rarr;</h3>
-              <p>Learn when to use EMOM vs. intervals vs. Tabata and how to set up each format.</p>
+              <p>Learn when to use EMOM vs. intervals vs. Tabata vs. For Time and how to set up each format.</p>
             </a>
           </li>
         </ul>

--- a/docs/for-time-timer.html
+++ b/docs/for-time-timer.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>For Time Timer for CrossFit — WODrounds</title>
+  <meta name="description" content="For Time timer for CrossFit and functional fitness. The clock counts up from zero; press Stop when you finish. Optional time cap. iPhone, Apple Watch, Mac and Apple TV.">
+  <meta name="keywords" content="for time timer, CrossFit for time, count up timer, workout stopwatch, WOD timer, time cap timer, Apple Watch for time timer">
+  <link rel="canonical" href="https://wodrounds.iamjarl.com/for-time-timer.html">
+  <meta name="robots" content="index, follow">
+  <link rel="alternate" hreflang="en" href="https://wodrounds.iamjarl.com/for-time-timer.html">
+  <link rel="alternate" hreflang="x-default" href="https://wodrounds.iamjarl.com/for-time-timer.html">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://wodrounds.iamjarl.com/for-time-timer.html">
+  <meta property="og:title" content="For Time Timer for CrossFit — WODrounds">
+  <meta property="og:description" content="The clock counts up from zero; press Stop when you finish. Optional time cap. iPhone, Watch, Mac, Apple TV.">
+  <meta property="og:image" content="https://wodrounds.iamjarl.com/images/og-image.png">
+  <meta property="og:site_name" content="WODrounds">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="750">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="For Time Timer for CrossFit — WODrounds">
+  <meta name="twitter:description" content="Count up from zero, press Stop when you finish. Optional time cap. iPhone, Watch, Mac, Apple TV.">
+  <meta name="twitter:image" content="https://wodrounds.iamjarl.com/images/og-image.png">
+  <meta name="theme-color" content="#0a0a0a">
+  <meta name="apple-itunes-app" content="app-id=6759229877">
+  <link rel="icon" href="images/favicon-dark.png" type="image/png" media="(prefers-color-scheme: dark)">
+  <link rel="icon" href="images/favicon-light.png" type="image/png" media="(prefers-color-scheme: light)">
+  <link rel="icon" href="images/favicon-dark.png" type="image/png">
+  <link rel="apple-touch-icon" href="images/favicon-dark.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,600;9..40,700&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+  <link rel="stylesheet" href="style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "WODrounds", "item": "https://wodrounds.iamjarl.com/" },
+      { "@type": "ListItem", "position": 2, "name": "For Time Timer" }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "name": "How to run a For Time workout with WODrounds",
+    "description": "Time a For Time WOD in the WODrounds app: the clock counts up and you press Stop when you finish, with an optional time cap.",
+    "step": [
+      { "@type": "HowToStep", "position": 1, "name": "Select For Time mode", "text": "Open WODrounds and tap For Time at the top of the screen." },
+      { "@type": "HowToStep", "position": 2, "name": "Set an optional time cap", "text": "Leave the cap on 'No cap' to run until you stop, or set a cap from 0:30 to 60:00 and the timer stops there automatically." },
+      { "@type": "HowToStep", "position": 3, "name": "Start", "text": "Tap Start. A 10-second countdown plays, then the clock counts up from zero." },
+      { "@type": "HowToStep", "position": 4, "name": "Finish", "text": "Press Stop the moment you complete the work. Your time is frozen and shown on the Done screen, and saved to Apple Health." }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is a For Time workout?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "For Time is a classic CrossFit format: you complete a set amount of work as fast as you can, and your score is the time it took. The clock counts up from zero while you work, and you stop it the moment you finish. It is the opposite of EMOM or interval training, where the clock and structure are fixed in advance."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is a time cap?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A time cap is an optional maximum time for a For Time workout. If you set one, the timer stops automatically when you reach it, so you are not left running the clock forever if the workout takes longer than planned. Caps are common for benchmark WODs, typically 10 to 20 minutes. In WODrounds you can set a cap from 0:30 to 60:00, or leave it on 'No cap' to run until you press Stop."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Does WODrounds save my For Time result?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. When you press Stop, your final time is frozen and shown on the Done screen as 'Finished in MM:SS', and the workout is saved to Apple Health as a HIIT session on iPhone. WODrounds does not keep its own workout history or log; it is a timer, not a tracker."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap">
+      <a href="index.html" class="logo"><img src="images/logo-light.svg" alt="" class="logo-icon" width="28" height="28" aria-hidden="true"> WODrounds</a>
+      <nav class="nav" aria-label="Main navigation">
+        <a href="guide.html">Guide</a>
+        <a href="privacy.html">Privacy</a>
+        <a href="support.html">Support</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="wrap">
+        <p class="hero-label">Count up &middot; Finish fast</p>
+        <h1 class="hero-title">For Time Timer<br>for CrossFit</h1>
+        <p class="hero-lead">The clock counts up from zero. Press Stop the moment you finish and your time is saved. Set an optional time cap and the timer stops there automatically. Runs on iPhone, iPad, Apple Watch, Mac and Apple TV, with no account, no subscription, and no ads.</p>
+        <p class="hero-cta">
+          <a href="https://apps.apple.com/app/wodrounds/id6759229877" class="btn btn-primary btn-large">Download on the App Store</a>
+          <span class="cta-note">iPhone &middot; iPad &middot; Apple Watch &middot; Mac &middot; Apple TV</span>
+        </p>
+      </div>
+    </section>
+
+    <section class="detail-section">
+      <div class="wrap">
+        <div class="detail-grid">
+          <div class="detail-text">
+            <h2 class="section-title">What is For Time?</h2>
+            <p class="section-lead">For Time is the classic CrossFit scoring format: complete a set amount of work as fast as you can, and your score is the time on the clock. Think 21-15-9 couplets, a set number of rounds, or a benchmark WOD.</p>
+            <p class="section-lead">Instead of a fixed countdown, the clock counts up while you work. You press Stop the instant you finish, and WODrounds freezes your time. Add a cap when you want a hard limit, or leave it off and just race the clock.</p>
+          </div>
+          <figure class="detail-image">
+            <img src="images/hero-screenshot.png" alt="WODrounds timer on iPhone" width="375" height="812" loading="lazy">
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section class="features">
+      <div class="wrap">
+        <h2 class="section-title">How For Time works in WODrounds</h2>
+        <ul class="feature-grid">
+          <li class="feature">
+            <span class="feature-icon" aria-hidden="true">Up</span>
+            <h3>The clock counts up</h3>
+            <p>Start at zero and go. The elapsed time is the headline, big and readable, so you always know where you stand.</p>
+          </li>
+          <li class="feature">
+            <span class="feature-icon" aria-hidden="true">Cap</span>
+            <h3>Optional time cap</h3>
+            <p>Leave it on "No cap" to run until you stop, or set a cap from 0:30 to 60:00 and the timer ends there automatically.</p>
+          </li>
+          <li class="feature">
+            <span class="feature-icon" aria-hidden="true">Stop</span>
+            <h3>Stop saves your time</h3>
+            <p>Press Stop the moment you finish. Your time is frozen and shown as "Finished in MM:SS", and saved to Apple Health.</p>
+          </li>
+          <li class="feature">
+            <span class="feature-icon" aria-hidden="true">Sync</span>
+            <h3>Follows on Apple Watch</h3>
+            <p>Start on iPhone and your Apple Watch counts up on your wrist too. Also runs on Mac and Apple TV.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="principles">
+      <div class="wrap">
+        <h2 class="section-title">Example For Time workouts</h2>
+        <div class="workout-examples">
+          <div class="workout-card">
+            <h3>21-15-9 couplet</h3>
+            <p class="workout-settings">For Time &middot; Cap 10:00</p>
+            <ul>
+              <li>21, then 15, then 9 reps of:</li>
+              <li>Thrusters</li>
+              <li>Pull-ups</li>
+              <li>Race the clock, cap at 10 minutes</li>
+            </ul>
+          </div>
+          <div class="workout-card">
+            <h3>5 rounds for time</h3>
+            <p class="workout-settings">For Time &middot; Cap 20:00</p>
+            <ul>
+              <li>5 rounds of:</li>
+              <li>10 burpees</li>
+              <li>15 kettlebell swings</li>
+              <li>20 air squats</li>
+            </ul>
+          </div>
+          <div class="workout-card">
+            <h3>Chipper</h3>
+            <p class="workout-settings">For Time &middot; No cap</p>
+            <ul>
+              <li>Work through a long list once</li>
+              <li>100 reps, split across movements</li>
+              <li>No cap: run until you finish</li>
+            </ul>
+          </div>
+        </div>
+        <p style="margin-top:1.5rem"><a href="guide.html" class="link-back">See the full timer guide &rarr;</a></p>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="wrap">
+        <h2 class="section-title">Time your next For Time WOD</h2>
+        <p class="cta-lead">Available on iPhone, iPad, Apple Watch, Mac and Apple TV.</p>
+        <a href="https://apps.apple.com/app/wodrounds/id6759229877" class="btn btn-primary btn-large">Download WODrounds</a>
+        <span class="cta-note">No account needed. Works offline.</span>
+      </div>
+    </section>
+
+    <section class="features">
+      <div class="wrap">
+        <h2 class="section-title">Related</h2>
+        <ul class="feature-grid">
+          <li class="feature">
+            <a href="emom-timer.html" style="text-decoration:none;color:inherit">
+              <span class="feature-icon" aria-hidden="true">EMOM</span>
+              <h3>EMOM Timer &rarr;</h3>
+              <p>Every Minute on the Minute. Set rounds and round length for CrossFit-style pacing.</p>
+            </a>
+          </li>
+          <li class="feature">
+            <a href="interval-timer.html" style="text-decoration:none;color:inherit">
+              <span class="feature-icon" aria-hidden="true">Work</span>
+              <h3>Interval Timer &rarr;</h3>
+              <p>Set work, rest and rounds for HIIT and circuit training.</p>
+            </a>
+          </li>
+          <li class="feature">
+            <a href="tabata-timer.html" style="text-decoration:none;color:inherit">
+              <span class="feature-icon" aria-hidden="true">20/10</span>
+              <h3>Tabata Timer &rarr;</h3>
+              <p>20 seconds on, 10 seconds off, 8 rounds. The classic Tabata protocol in WODrounds.</p>
+            </a>
+          </li>
+          <li class="feature">
+            <a href="guide.html" style="text-decoration:none;color:inherit">
+              <span class="feature-icon" aria-hidden="true">Guide</span>
+              <h3>Timer Guide &rarr;</h3>
+              <p>Learn when to use EMOM vs. intervals vs. Tabata vs. For Time and how to set up each format.</p>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <p class="footer-logo">WODrounds</p>
+      <p class="footer-links">
+        <a href="guide.html">Guide</a>
+        <a href="privacy.html">Privacy</a>
+        <a href="support.html">Support</a>
+      </p>
+      <p class="footer-copy">Built in Copenhagen by <a href="https://iamjarl.com" class="footer-author">IAMJARL</a>. <a href="privacy.html">Privacy Policy</a> covers the app and this website.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -135,13 +135,14 @@
           <li><strong>EMOM</strong> uses a fixed clock where your rest is the leftover time in each round. Pace yourself or suffer.</li>
           <li><strong>HIIT</strong> (High-Intensity Interval Training) is a broad category. Any workout alternating high effort and rest qualifies. Tabata is a form of HIIT. So is 40 seconds on, 20 seconds off.</li>
           <li><strong>Tabata</strong> is a specific HIIT protocol: 20/10 for 8 rounds at maximum effort.</li>
+          <li><strong><a href="for-time-timer.html">For Time</a></strong> flips the clock around: instead of a fixed structure, you complete a set amount of work as fast as you can and the clock counts up until you finish.</li>
         </ul>
-        <p>WODrounds handles all three. Use EMOM mode for EMOMs and Intervals mode for HIIT and Tabata.</p>
+        <p>WODrounds handles all of these. Use EMOM mode for EMOMs, Intervals mode for HIIT and Tabata, and <a href="for-time-timer.html">For Time</a> mode to race the clock with an optional cap.</p>
 
         <h2 id="setup">How to set up your timer</h2>
         <p>WODrounds is designed to get you started in seconds:</p>
         <ol class="setup-steps">
-          <li><strong>Choose your mode.</strong> EMOM or Intervals. Tap the toggle at the top of the screen.</li>
+          <li><strong>Choose your mode.</strong> EMOM, Intervals or For Time. Tap the toggle at the top of the screen.</li>
           <li><strong>Set your numbers.</strong> For EMOM: rounds and round length. For Intervals: work seconds, rest seconds, and rounds.</li>
           <li><strong>Press Start.</strong> A 10-second countdown gives you time to get in position. Sound cues tell you when each round starts and when 30 seconds remain.</li>
           <li><strong>Train.</strong> The timer runs in the background, on your Apple Watch, or on your TV. Pause or cancel anytime.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,8 +62,8 @@
       "https://wodrounds.iamjarl.com/images/mac-overview.png",
       "https://wodrounds.iamjarl.com/images/appletv.png"
     ],
-    "featureList": "EMOM timer, Interval timer, Tabata presets, iPhone to Watch sync, Apple Health integration, Apple TV support, Mac support, Dark mode, No accounts required",
-    "softwareVersion": "1.4",
+    "featureList": "EMOM timer, Interval timer, For Time timer, Tabata presets, iPhone to Watch sync, Apple Health integration, Apple TV support, Mac support, Dark mode, No accounts required",
+    "softwareVersion": "1.5",
     "author": {
       "@type": "Person",
       "name": "Jarl Lyng",
@@ -94,10 +94,18 @@
       },
       {
         "@type": "Question",
+        "name": "Can I time a For Time WOD?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. Switch to For Time mode and the clock counts up from zero. Press Stop when you finish and your time is saved. You can set an optional time cap (0:30 to 60:00) so the timer stops automatically, or leave it uncapped to run until you stop it."
+        }
+      },
+      {
+        "@type": "Question",
         "name": "Does WODrounds work on Apple TV?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Yes. WODrounds is a native app on Apple TV. Navigate with the Siri Remote and see your timer on the big screen. It supports both EMOM and Intervals mode with sound cues."
+          "text": "Yes. WODrounds is a native app on Apple TV. Navigate with the Siri Remote and see your timer on the big screen. It supports EMOM, Intervals and For Time with sound cues."
         }
       },
       {
@@ -270,8 +278,8 @@
       <div class="wrap detail-content">
         <div class="detail-grid">
           <div class="detail-text feature-glass">
-            <h2 class="section-title">EMOM or Intervals.<br>Your call.</h2>
-            <p class="section-lead">Two modes, zero bloat. EMOM gives you a round counter with a configurable minute. Intervals give you work, rest and rounds. Both modes support sound cues and a 10-second countdown to get ready.</p>
+            <h2 class="section-title">EMOM, Intervals<br>or For Time.</h2>
+            <p class="section-lead">Three modes, zero bloat. EMOM gives you a round counter with a configurable minute. Intervals give you work, rest and rounds. <a href="for-time-timer.html">For Time</a> counts up from zero so you can race the clock, with an optional cap. Every mode has a 10-second countdown to get ready.</p>
             <ul class="check-list">
               <li>10-second countdown before every workout</li>
               <li>Halfway and ten-seconds voice cues, plus a 3-2-1 countdown</li>
@@ -315,8 +323,12 @@
             <dd>Yes. Tabata is a type of interval training with 20 seconds of work and 10 seconds of rest for 8 rounds. In WODrounds, switch to Intervals mode and set work to 20, rest to 10, and rounds to 8.</dd>
           </div>
           <div class="faq-item">
+            <dt>Can I time a <a href="for-time-timer.html">For Time</a> WOD?</dt>
+            <dd>Yes. Switch to For Time mode and the clock counts up from zero. Press Stop when you finish and your time is saved. You can set an optional time cap (0:30 to 60:00) so the timer stops automatically, or leave it uncapped to run until you stop it.</dd>
+          </div>
+          <div class="faq-item">
             <dt>Does WODrounds work on Apple TV?</dt>
-            <dd>Yes. WODrounds is a native app on Apple TV. Navigate with the Siri Remote and see your timer on the big screen. It supports both EMOM and Intervals mode with sound cues.</dd>
+            <dd>Yes. WODrounds is a native app on Apple TV. Navigate with the Siri Remote and see your timer on the big screen. It supports EMOM, Intervals and For Time with sound cues.</dd>
           </div>
           <div class="faq-item">
             <dt>Do I need an iPhone to use the Apple Watch app?</dt>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -31,6 +31,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://wodrounds.iamjarl.com/for-time-timer.html</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://wodrounds.iamjarl.com/emom-workout-examples.html</loc>
     <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>

--- a/docs/tabata-timer.html
+++ b/docs/tabata-timer.html
@@ -245,10 +245,17 @@
             </a>
           </li>
           <li class="feature">
+            <a href="for-time-timer.html" style="text-decoration:none;color:inherit">
+              <span class="feature-icon" aria-hidden="true">For Time</span>
+              <h3>For Time Timer &rarr;</h3>
+              <p>Count up from zero and race the clock, with an optional time cap. For classic For Time WODs.</p>
+            </a>
+          </li>
+          <li class="feature">
             <a href="guide.html" style="text-decoration:none;color:inherit">
               <span class="feature-icon" aria-hidden="true">Guide</span>
               <h3>Timer Guide &rarr;</h3>
-              <p>Learn when to use EMOM vs. intervals vs. Tabata and how to set up each format.</p>
+              <p>Learn when to use EMOM vs. intervals vs. Tabata vs. For Time and how to set up each format.</p>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Adds `paths-ignore` to tests.yml and codeql.yml so a PR that changes only `docs/`, markdown, GitHub templates, or LICENSE skips the Swift build and the ~30 min CodeQL analysis. docs.yml already scopes to the site; the weekly scheduled CodeQL scan still covers everything. No required checks depend on these, so skipping never blocks a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)