### PR TITLE
Fix two iOS UI regressions from the 1.5 third mode (1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable user-facing changes to WODrounds. Newest first.
 
+## 1.5.1 (build 15)
+
+**What's New (App Store copy):**
+
+> • Fixed the info button overlapping the For Time tab on iPhone.
+> • Tidied the About screen so Support and Privacy Policy sit correctly.
+
+**Details:**
+
+- **Fixed (iOS):** with the third mode added in 1.5, the setup screen's mode switch reached under the pinned top-right controls, so the info icon overlapped the "For Time" tab. The mode switch now clears the controls.
+- **Fixed (iOS/macOS/tvOS):** the About screen's Support and Privacy Policy links were left-aligned in a block that then centered as a narrow column, reading as "pushed toward the middle". They now center like the rest of the screen.
+
 ## 1.5 (build 13 on iOS; build 14 on macOS/tvOS)
 
 **What's New (App Store copy):**

--- a/WODrounds.xcodeproj/project.pbxproj
+++ b/WODrounds.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=appletvos*]" = "WODrounds/WODrounds-tvOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "WODrounds/WODrounds-Mac.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				ENABLE_APP_SANDBOX = YES;
@@ -587,7 +587,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
@@ -614,7 +614,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=appletvos*]" = "WODrounds/WODrounds-tvOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "WODrounds/WODrounds-Mac.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				ENABLE_APP_SANDBOX = YES;
@@ -642,7 +642,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
@@ -664,13 +664,13 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -690,13 +690,13 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -715,13 +715,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -740,13 +740,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -768,14 +768,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WODroundsWatch/WODroundsWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "WODroundsWatch-Info.plist";
 				INFOPLIST_KEY_CFBundleIconName = AppIcon;
 				INFOPLIST_KEY_LSApplicationCategory = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.iamjarl.WODrounds;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -795,14 +795,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WODroundsWatch/WODroundsWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "WODroundsWatch-Info.plist";
 				INFOPLIST_KEY_CFBundleIconName = AppIcon;
 				INFOPLIST_KEY_LSApplicationCategory = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.iamjarl.WODrounds;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/WODrounds/iOSContentView.swift
+++ b/WODrounds/iOSContentView.swift
@@ -271,6 +271,9 @@ private struct iOSContent: View {
     }
 
     private var idleHeaderView: some View {
+        // Top inset clears the pinned top-right controls (44pt touch targets):
+        // with three mode segments the switch now reaches the right edge, so
+        // "For Time" would sit under the info icon without this.
         VStack(spacing: DesignTokens.Spacing.md * spacingScale) {
             SharedModeSwitch(timerMode: $timerMode, onModeChange: { syncEngineIfIdle(engine.state) }, theme: modeSwitchTheme)
             Text(modeHelpText)
@@ -281,6 +284,7 @@ private struct iOSContent: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, DesignTokens.Spacing.xl)
         }
+        .padding(.top, 44)
     }
 
     private func activeTimerView(snapshot: WODTimerEngineSnapshot, totalRounds: Int) -> some View {
@@ -629,7 +633,10 @@ private struct AboutView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
-            VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            // Centered to match the rest of the About screen. A leading-aligned
+            // VStack shrinks to its content and then centers as a narrow block,
+            // which read as "pushed toward the middle".
+            VStack(spacing: DesignTokens.Spacing.sm) {
                 if let url = URL(string: "https://wodrounds.iamjarl.com/support") {
                     Link(destination: url) {
                         Text("Support")
@@ -645,6 +652,7 @@ private struct AboutView: View {
                     }
                 }
             }
+            .frame(maxWidth: .infinity)
             .padding(.horizontal)
 
             Spacer()

--- a/WODrounds/macOSContentView.swift
+++ b/WODrounds/macOSContentView.swift
@@ -391,7 +391,7 @@ private struct MacAboutView: View {
                 .font(.system(size: DesignTokens.Typography.Size.base, weight: DesignTokens.Typography.Weight.regular, design: .monospaced))
                 .foregroundStyle(DesignTokens.Common.Text.secondary(scheme))
                 .multilineTextAlignment(.center)
-            VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            VStack(spacing: DesignTokens.Spacing.sm) {
                 if let url = URL(string: "https://wodrounds.iamjarl.com/support") {
                     Link(destination: url) {
                         Text("Support")
@@ -407,6 +407,7 @@ private struct MacAboutView: View {
                     }
                 }
             }
+            .frame(maxWidth: .infinity)
             Spacer()
             Button("Done") { dismiss() }
                 .font(.system(size: DesignTokens.Typography.Size.base, weight: DesignTokens.Typography.Weight.semibold, design: .monospaced))

--- a/WODrounds/tvOSContentView.swift
+++ b/WODrounds/tvOSContentView.swift
@@ -500,7 +500,7 @@ private struct tvOSAboutView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
-            VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
+            VStack(spacing: DesignTokens.Spacing.sm) {
                 if let url = URL(string: "https://wodrounds.iamjarl.com/support") {
                     Link(destination: url) {
                         Text("Support")
@@ -516,6 +516,7 @@ private struct tvOSAboutView: View {
                     }
                 }
             }
+            .frame(maxWidth: .infinity)
             .padding(.horizontal)
 
             Spacer()


### PR DESCRIPTION
Two UI bugs surfaced by adding the third mode (For Time) in 1.5, both found on iPhone.

## Fixes
1. **Info icon overlapped the "For Time" tab (iOS).** The third segment widened the idle mode switch so its right edge reached under the pinned top-right controls. The header now has a top inset that drops the mode switch below the controls. Verified in the simulator.
2. **About screen links looked "pushed toward the middle" (iOS/macOS/tvOS).** Support / Privacy Policy were in a leading-aligned VStack that shrank to its content and centered as a narrow column. They now span full width and center like the rest of the screen. Fixed on all three platforms (same root cause).

## Verification
- iOS: both screens screenshotted in the simulator (mode switch clear of the icon; links centered).
- macOS + tvOS + Watch build; iOS builds via the UI test target.

## Release
`MARKETING_VERSION 1.5.1`, build 15 (higher than the 13/14 used by 1.5 across platforms). Ready to archive + submit as a 1.5.1 patch when you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)