### PR TITLE
ci: Xcode Cloud post-clone script for Sentry.xcconfig

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Xcode Cloud runs this immediately after cloning the repository.
+#
+# Sentry.xcconfig is gitignored (see .gitignore), so a fresh clone has no
+# config file and the build fails at the `#include "Sentry.xcconfig"` reference.
+# Recreate it here from the SENTRY_DSN environment variable, which you set as a
+# (secret) environment variable on the Xcode Cloud workflow.
+#
+# If SENTRY_DSN is not set, we still write the file with an empty value: the app
+# treats an empty DSN as "crash reporting disabled" (see WODroundsApp.swift), so
+# the archive still succeeds. That makes the script safe for test-only workflows
+# too. The DSN is a public client credential (it ships in the app binary), so a
+# workflow env var is an appropriate place for it.
+
+set -e
+
+CONFIG="${CI_PRIMARY_REPOSITORY_PATH:-..}/Sentry.xcconfig"
+printf 'SENTRY_DSN = %s\n' "${SENTRY_DSN}" > "$CONFIG"
+
+if [ -n "${SENTRY_DSN}" ]; then
+  echo "ci_post_clone: wrote Sentry.xcconfig with a DSN"
+else
+  echo "ci_post_clone: wrote Sentry.xcconfig with an empty DSN (crash reporting off)"
+fi

--- a/docs/SENTRY.md
+++ b/docs/SENTRY.md
@@ -23,6 +23,12 @@ The app reads the DSN in this order: **1)** environment variable `SENTRY_DSN` (e
 
 **If Sentry still doesn't receive events:** In Debug, the Xcode console will show `[Sentry] No DSN: ...` if no DSN was found. Verify that the environment variable is set under Run, or that `Sentry.xcconfig` is used as base config for the WODrounds target.
 
+### C) Xcode Cloud (archives in CI)
+
+`Sentry.xcconfig` is gitignored, so a fresh Xcode Cloud clone has no config file and the build fails at the xcconfig reference. `ci_scripts/ci_post_clone.sh` recreates it after clone from the `SENTRY_DSN` environment variable.
+
+To set it up: in the Xcode Cloud workflow, add an environment variable named `SENTRY_DSN` (mark it secret) with your real DSN. If it is left unset, the script writes an empty DSN and crash reporting is simply off for that build (the archive still succeeds). Same for GitHub Actions, which copies `Sentry.xcconfig.example` instead (see `.github/workflows/`).
+
 ## Adding the Sentry Package (Swift Package)
 
 If you haven't added the package yet:


### PR DESCRIPTION
Repo half of setting up Xcode Cloud properly (see the Xcode Cloud discussion).

`Sentry.xcconfig` is gitignored, so Xcode Cloud archives fail at the xcconfig reference on a fresh clone. This is the likely cause of the failing iOS/macOS Archive actions. `ci_scripts/ci_post_clone.sh` recreates it after clone from the `SENTRY_DSN` workflow environment variable (empty DSN → crash reporting off, archive still succeeds). Documented in `docs/SENTRY.md`.

The rest is App Store Connect / Xcode Cloud UI config (my message has the steps): trigger on release tags only, drop the visionOS action, keep iOS/macOS/tvOS, add the `SENTRY_DSN` secret, distribute to TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)