### PR TITLE
docs: release runbook (Xcode Cloud via release branch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Target audience, positioning, pricing reasoning, SEO/ASO playbooks, and competit
 ## Requirements & build
 - Open `WODrounds.xcodeproj`; scheme **WODrounds** (iOS) or **WODrounds Watch** (watchOS).
 - Tests: `WODroundsTests` uses Swift Testing (**Product → Test** / ⌘U).
+- Releasing: Xcode Cloud builds/uploads all platforms when the `release` branch moves (`git push origin main:release`); `main` pushes never build. Do not archive manually. Runbook: `docs/RELEASING.md`.
 - Docs: run `python3 scripts/validate_docs.py` before committing docs changes (also enforced by `.github/workflows/docs.yml`).
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The app follows the IAMJARL design system via SPM package ([iamjarl-design](http
 - **Xcode:** Open `WODrounds.xcodeproj`. Select scheme **WODrounds** (iOS) or **WODrounds Watch** (watchOS). Build and run on simulator or device.
 - **iOS + Watch:** Use "Any iOS Device" (or a physical iPhone) to run the main app; the Watch app is embedded and installs with the iOS app.
 - **Tests:** `WODroundsTests` uses Swift Testing; run tests via **Product → Test** or `⌘U`.
+- **Releasing:** builds ship via Xcode Cloud, triggered by moving the `release` branch (`git push origin main:release`); `main` pushes never build. Full runbook in [docs/RELEASING.md](docs/RELEASING.md).
 - **Docs validation:** Run `python3 scripts/validate_docs.py` before committing docs changes. Also runs automatically on every push to `main` via `.github/workflows/docs.yml`. Checks image references, App Store URLs, JSON-LD validity, sitemap integrity, and canonical URLs.
 - **Sales / downloads:** `scripts/asc_downloads.py` pulls App Store Connect download numbers (new installs vs. updates) from the command line. Credentials stay local — see [scripts/README.md](scripts/README.md). No secrets are committed (`*.p8` and `.env` are gitignored).
 
@@ -152,6 +153,7 @@ Detailed reference docs live in `docs/`:
 | [ARCHIVE.md](docs/ARCHIVE.md) | Archive destinations, platform filtering, entitlements |
 | [APP_ICONS.md](docs/APP_ICONS.md) | Icon asset checklist for all platforms |
 | [APP_STORE_CONNECT.md](docs/APP_STORE_CONNECT.md) | App Store text (subtitle, description, keywords) for iOS, Mac, tvOS |
+| [RELEASING.md](docs/RELEASING.md) | Release runbook: Xcode Cloud (release-branch trigger), version bumps, App Store submission |
 | [SENTRY.md](docs/SENTRY.md) | Crash reporting setup (iOS only) |
 
 Other root-level docs:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,40 @@
+# Releasing WODrounds
+
+How a release reaches the App Store. Two separate CI systems, one job each:
+
+- **GitHub Actions** runs on pull requests: unit tests, CodeQL, and docs validation. It never builds a release. (Docs-only PRs skip the Swift build and CodeQL via `paths-ignore`; see `.github/workflows/`.)
+- **Xcode Cloud** builds and uploads release archives. It runs **only** when the `release` branch moves, so normal pushes and merges to `main` never trigger a build.
+
+## The release flow
+
+1. **Bump the version and build number** in `WODrounds.xcodeproj` (target → General, or edit `project.pbxproj`):
+   - `MARKETING_VERSION` (e.g. `1.5.1`) for a user-visible version.
+   - `CURRENT_PROJECT_VERSION` (the build number). **Always increase it.** App Store Connect enforces the build number across the whole app record, not per platform, so reusing a number fails with error 90061 even on a platform that never uploaded it. When in doubt, bump.
+2. **Update `CHANGELOG.md`** with a new top entry (What's New copy + details).
+3. **If anything user-facing changed:** update `docs/APP_STORE_CONNECT.md` (description / keywords / What's New, EN + es-MX) and the marketing site under `docs/`. Run `python3 scripts/validate_docs.py`.
+4. **Merge to `main`** via a pull request, as usual. (This does not build anything.)
+5. **Trigger the release build** by moving the `release` branch to the new `main`:
+   ```sh
+   git push origin main:release
+   ```
+   Xcode Cloud's "Default" workflow archives iOS, macOS and tvOS (build number from step 1), runs `ci_scripts/ci_post_clone.sh` to recreate the gitignored `Sentry.xcconfig`, and uploads all three to App Store Connect.
+6. **In App Store Connect:** the builds appear under **TestFlight → Builds**. Test on hardware if you want, then in each platform's **Prepare for Submission** add the build to the version and **submit**. (Xcode Cloud uploads but does not auto-submit to review.)
+
+That is the whole loop. No manual Xcode archives.
+
+## Xcode Cloud configuration (reference)
+
+Configured in App Store Connect → WODrounds → Xcode Cloud → Manage Workflows → **Default**. It is not stored in this repo (only `ci_scripts/` is), so this is the record of how it is set up:
+
+- **Start Condition:** Branch Changes on **`release`** (this is the only condition; there is deliberately no `main` or tag trigger).
+- **Actions:** three Archive actions, one each for **iOS**, **macOS** (Build For: Any Mac) and **tvOS**, scheme **WODrounds**, Distribution Preparation = **App Store Connect**.
+- **Environment variable:** `SENTRY_DSN` (marked secret) holds the real Sentry DSN. `ci_scripts/ci_post_clone.sh` writes it into `Sentry.xcconfig` after clone. If it were unset the archive still succeeds with crash reporting off (see [SENTRY.md](SENTRY.md)).
+- **Post-Actions:** none needed (the Archive action's "App Store Connect" distribution does the upload).
+
+## Why a `release` branch and not a git tag
+
+We first tried triggering on version tags (`v*`). Xcode Cloud's GitHub integration did not pick the tags up for this repo (they never appeared for auto-builds or in the manual Start Build list, even after re-pushing and waiting hours). Branch triggers work reliably here, so the release trigger is a dedicated `release` branch instead. Version tags may still be created as plain markers, but they do not drive CI.
+
+## Fallback: manual archive
+
+If Xcode Cloud is unavailable, you can still release the old way: in Xcode, select the WODrounds scheme and Archive once per destination (Any iOS Device, Any Mac, Any tvOS Device), then Distribute from the Organizer. Make sure the build number is higher than anything already uploaded (see step 1), and pick the newest archive in the Organizer, not a stale one.


### PR DESCRIPTION
Documents the now-working release process so it isn't tribal knowledge.

- **New `docs/RELEASING.md`:** the GitHub Actions (PR tests) vs Xcode Cloud (release archiving) split; the step-by-step flow (bump version + build number → changelog → merge to main → `git push origin main:release` → submit in App Store Connect); the Xcode Cloud workflow config for reference; and the lessons learned (build numbers enforced across platforms; tag triggers were unreliable so we use a `release` branch; `ci_post_clone.sh` generates `Sentry.xcconfig`; manual-archive fallback).
- **README:** linked in Build & run + the docs table.
- **CLAUDE.md:** one-line pointer so future sessions know releases go via the `release` branch, not manual archives.

Docs-only, so it does not trigger a build and CI runs only docs-validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)