### PR TITLE
Cross-link Anvil Workout + queue expanded ASO keywords

### DIFF
--- a/docs/APP_STORE_CONNECT.md
+++ b/docs/APP_STORE_CONNECT.md
@@ -83,11 +83,11 @@ iOS: "New: For Time mode. The clock counts up from zero; press Stop when you fin
 
 Search terms users may search for. **Do not repeat words from the app name or subtitle** (Apple weights them lower). Prioritize high-intent words; one comma between each, no spaces after commas.
 
-```
-interval timer,workout timer,EMOM,Tabata,HIIT,CrossFit,gym,countdown,Apple Watch
-```
+**Apply with the next release** (keywords only update when a new version ships). Expanded field, ~99 of 100 chars (was ~65):
 
-(About 65 characters — there's room for e.g. `stopwatch` or `functional fitness` if desired.)
+```
+interval timer,workout timer,EMOM,Tabata,HIIT,CrossFit,gym,countdown,Apple Watch,functional,WOD,fit
+```
 
 ---
 
@@ -196,8 +196,10 @@ The same minimal WOD timer as on iPhone and Apple Watch – no database, no shar
 
 ## Keywords (max 100 characters)
 
+**Apply with the next release.** Expanded field (~98 of 100 chars):
+
 ```
-interval timer,workout timer,EMOM,Tabata,HIIT,CrossFit,gym,countdown,Mac
+interval timer,workout timer,EMOM,Tabata,HIIT,CrossFit,gym,countdown,Mac,desktop timer,WOD,fitness
 ```
 
 ## Screenshots (Mac)

--- a/docs/about.html
+++ b/docs/about.html
@@ -141,10 +141,11 @@
         <h2>More from IAMJARL</h2>
         <p>WODrounds is one of several small projects I work on. Each is single-purpose and free of accounts, ads, and tracking:</p>
         <ul>
-          <li><a href="https://weannicotine.iamjarl.com" rel="external">Wean Nicotine</a> — a structured nicotine reduction tool</li>
-          <li><a href="https://madebyhuman.iamjarl.com" rel="external">Made by Human</a> — badges for content disclosing human vs. AI authorship</li>
-          <li><a href="https://gettothemovie.iamjarl.com" rel="external">Get to the Movie!</a> — film timing planner</li>
-          <li><a href="https://trimrpix.iamjarl.com" rel="external">TrimrPix</a> — image trimming utility</li>
+          <li><a href="https://anvilworkout.iamjarl.com" rel="external">Anvil Workout</a>: a pay-once strength log for iPhone, iPad and Apple Watch. Log your lifting there, time your conditioning here.</li>
+          <li><a href="https://weannicotine.iamjarl.com" rel="external">Wean Nicotine</a>: a structured nicotine reduction tool</li>
+          <li><a href="https://madebyhuman.iamjarl.com" rel="external">Made by Human</a>: badges for content disclosing human vs. AI authorship</li>
+          <li><a href="https://gettothemovie.iamjarl.com" rel="external">Get to the Movie!</a>: film timing planner</li>
+          <li><a href="https://trimrpix.iamjarl.com" rel="external">TrimrPix</a>: image trimming utility</li>
           <li><a href="https://iamjarl.com" rel="external">All projects on iamjarl.com</a></li>
         </ul>
 

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -227,6 +227,7 @@
       </p>
       <p class="footer-links" style="margin-top:0.5rem;font-size:0.85em;opacity:0.75;">More from IAMJARL</p>
       <p class="footer-links">
+        <a href="https://anvilworkout.iamjarl.com">Anvil Workout</a>
         <a href="https://weannicotine.iamjarl.com">Wean Nicotine</a>
         <a href="https://gettothemovie.iamjarl.com">Get to the Movie!</a>
         <a href="https://trimrpix.iamjarl.com">TrimrPix</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -372,6 +372,7 @@
       </p>
       <p class="footer-links" style="margin-top:0.5rem;font-size:0.85em;opacity:0.75;">More from IAMJARL</p>
       <p class="footer-links">
+        <a href="https://anvilworkout.iamjarl.com">Anvil Workout</a>
         <a href="https://weannicotine.iamjarl.com">Wean Nicotine</a>
         <a href="https://gettothemovie.iamjarl.com">Get to the Movie!</a>
         <a href="https://trimrpix.iamjarl.com">TrimrPix</a>


### PR DESCRIPTION
## What

Two small marketing items:

1. **Anvil Workout cross-link** on the marketing site: added first in the "More from IAMJARL" footer list on the homepage and guide, and to the About page list with a one-line description (strength log sibling). The About list's separators switch from em-dashes to colons.
2. **Expanded ASO keyword fields queued** in `docs/APP_STORE_CONNECT.md` for iOS (~99 chars) and Mac (~98 chars), marked "apply with the next release" since keywords only update when a new version ships.

`python3 scripts/validate_docs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)