### PR TITLE
Use first name only across the marketing site

### DIFF
--- a/docs/10-minute-hiit-workout.html
+++ b/docs/10-minute-hiit-workout.html
@@ -49,7 +49,7 @@
     "description": "Three 10-minute HIIT workouts you can do anywhere. Bodyweight, kettlebell and mixed.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {

--- a/docs/20-minute-hiit-workout.html
+++ b/docs/20-minute-hiit-workout.html
@@ -49,7 +49,7 @@
     "description": "Four 20-minute HIIT workouts for CrossFit and functional fitness with exact timer settings.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {

--- a/docs/about.html
+++ b/docs/about.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>About — WODrounds, made by Jarl Lyng in Copenhagen</title>
-  <meta name="description" content="WODrounds is built by Jarl Lyng, a Copenhagen-based developer and CrossFitter. Here is why I built a minimal timer app for Apple devices and how I keep it that way.">
-  <meta name="keywords" content="Jarl Lyng, IAMJARL, WODrounds creator, indie iOS developer, Copenhagen, about WODrounds">
+  <title>About — WODrounds, made by Jarl in Copenhagen</title>
+  <meta name="description" content="WODrounds is built by Jarl, a Copenhagen-based developer and CrossFitter. Here is why I built a minimal timer app for Apple devices and how I keep it that way.">
+  <meta name="keywords" content="Jarl, IAMJARL, WODrounds creator, indie iOS developer, Copenhagen, about WODrounds">
   <link rel="canonical" href="https://wodrounds.iamjarl.com/about.html">
   <meta name="robots" content="index, follow">
   <meta property="og:type" content="profile">
   <meta property="og:url" content="https://wodrounds.iamjarl.com/about.html">
-  <meta property="og:title" content="About WODrounds — made by Jarl Lyng in Copenhagen">
+  <meta property="og:title" content="About WODrounds — made by Jarl in Copenhagen">
   <meta property="og:description" content="Why I built a minimal timer for Apple devices and how I keep it that way.">
   <meta property="og:image" content="https://wodrounds.iamjarl.com/images/og-image.png">
   <meta property="og:site_name" content="WODrounds">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="750">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="About WODrounds — made by Jarl Lyng">
+  <meta name="twitter:title" content="About WODrounds — made by Jarl">
   <meta name="twitter:description" content="Why I built a minimal timer for Apple devices and how I keep it that way.">
   <meta name="twitter:image" content="https://wodrounds.iamjarl.com/images/og-image.png">
   <meta name="theme-color" content="#0a0a0a">
@@ -44,7 +44,7 @@
   {
     "@context": "https://schema.org",
     "@type": "Person",
-    "name": "Jarl Lyng",
+    "name": "Jarl",
     "alternateName": "IAMJARL",
     "jobTitle": "Indie iOS developer",
     "url": "https://iamjarl.com",
@@ -69,7 +69,7 @@
     "url": "https://wodrounds.iamjarl.com/about.html",
     "mainEntity": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     }
   }
@@ -92,12 +92,12 @@
     <article class="page-content">
       <div class="wrap">
         <h1 class="page-title">About WODrounds</h1>
-        <p class="byline">By Jarl Lyng · IAMJARL · Copenhagen</p>
+        <p class="byline">By Jarl · IAMJARL · Copenhagen</p>
 
         <p class="guide-intro">WODrounds is a single-purpose timer app for CrossFit, HIIT and interval training. I built it because every workout timer I tried wanted something from me. This page explains who I am, why I made it, and the principles that keep it small.</p>
 
         <h2>Who builds this</h2>
-        <p>I'm Jarl Lyng. I work as a developer in Copenhagen and have done consulting and software design for over a decade. Outside work I do CrossFit, lift weights, and play music. WODrounds is one of my indie projects under <a href="https://iamjarl.com" rel="external">IAMJARL</a> — a portfolio of small, focused tools that solve one problem each.</p>
+        <p>I'm Jarl. I work as a developer in Copenhagen and have done consulting and software design for over a decade. Outside work I do CrossFit, lift weights, and play music. WODrounds is one of my indie projects under <a href="https://iamjarl.com" rel="external">IAMJARL</a> — a portfolio of small, focused tools that solve one problem each.</p>
         <p>I built WODrounds alone. The code, the design, the marketing site, the App Store screenshots — all of it. That's a deliberate choice, not a humble brag: it means decisions are fast, scope is narrow, and there's no roadmap pressure from anyone but me.</p>
 
         <h2>Why I built it</h2>

--- a/docs/apple-watch-timer.html
+++ b/docs/apple-watch-timer.html
@@ -56,7 +56,7 @@
     "description": "Use WODrounds as your Apple Watch workout timer. EMOM and interval timing on your wrist.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {

--- a/docs/beginner-hiit-workout.html
+++ b/docs/beginner-hiit-workout.html
@@ -49,7 +49,7 @@
     "description": "Four beginner-friendly HIIT workouts with longer rest periods and simple movements.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {

--- a/docs/best-crossfit-timer-apps.html
+++ b/docs/best-crossfit-timer-apps.html
@@ -48,7 +48,7 @@
     "description": "An honest comparison of the best CrossFit timer apps including WODrounds, SmartWOD, Seconds and more.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {

--- a/docs/emom-workout-examples.html
+++ b/docs/emom-workout-examples.html
@@ -49,7 +49,7 @@
     "description": "5 ready-to-use EMOM workouts for CrossFit and functional fitness. Beginner to advanced.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -48,7 +48,7 @@
     "description": "A practical guide to EMOM, Tabata and interval timers for CrossFit, HIIT and functional fitness.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {

--- a/docs/home-gym-hiit-workout.html
+++ b/docs/home-gym-hiit-workout.html
@@ -49,7 +49,7 @@
     "description": "Four HIIT workouts designed for a home or garage gym with kettlebell, dumbbell and barbell.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,7 @@
     "softwareVersion": "1.5",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     }
   }

--- a/docs/tabata-workout-examples.html
+++ b/docs/tabata-workout-examples.html
@@ -49,7 +49,7 @@
     "description": "5 Tabata workouts using the classic 20/10 protocol. From single-exercise to full-body circuits.",
     "author": {
       "@type": "Person",
-      "name": "Jarl Lyng",
+      "name": "Jarl",
       "url": "https://iamjarl.com"
     },
     "publisher": {


### PR DESCRIPTION
## What

Replaces the full name with just "Jarl" everywhere on the marketing site: page titles, meta description/keywords, OG/Twitter titles, bylines, and the JSON-LD Person/author blocks (11 pages).

## Why

Prefer not to have the full name spelled out on the site. The IAMJARL brand carries authorship; the GitHub username remains in repo URLs since those can't change.

`python3 scripts/validate_docs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)