### PR TITLE
Add discreet Anvil Workout cross-promo to the About screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable user-facing changes to WODrounds. Newest first.
 
+## Unreleased
+
+- **Added (iOS/macOS):** a discreet "Also from IAMJARL" line on the About screen linking to Anvil Workout on the App Store. Not on tvOS (no browser hand-off there).
+- Reminder for the next release: apply the expanded App Store keyword fields from `docs/APP_STORE_CONNECT.md` (staged 2026-07-11; keywords only update when a version ships).
+
 ## 1.5.1 (build 15)
 
 **What's New (App Store copy):**

--- a/WODrounds/iOSContentView.swift
+++ b/WODrounds/iOSContentView.swift
@@ -651,6 +651,18 @@ private struct AboutView: View {
                             .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
                     }
                 }
+
+                Text("Also from IAMJARL")
+                    .font(.system(size: DesignTokens.Typography.Size.xs, weight: DesignTokens.Typography.Weight.regular, design: .monospaced))
+                    .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
+                    .padding(.top, DesignTokens.Spacing.lg)
+                if let url = URL(string: "https://apps.apple.com/app/id6760627760") {
+                    Link(destination: url) {
+                        Text("Anvil Workout: strength log")
+                            .font(.system(size: DesignTokens.Typography.Size.sm, weight: DesignTokens.Typography.Weight.regular, design: .monospaced))
+                            .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
+                    }
+                }
             }
             .frame(maxWidth: .infinity)
             .padding(.horizontal)

--- a/WODrounds/macOSContentView.swift
+++ b/WODrounds/macOSContentView.swift
@@ -406,6 +406,18 @@ private struct MacAboutView: View {
                             .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
                     }
                 }
+
+                Text("Also from IAMJARL")
+                    .font(.system(size: DesignTokens.Typography.Size.xs, weight: DesignTokens.Typography.Weight.regular, design: .monospaced))
+                    .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
+                    .padding(.top, DesignTokens.Spacing.lg)
+                if let url = URL(string: "https://apps.apple.com/app/id6760627760") {
+                    Link(destination: url) {
+                        Text("Anvil Workout: strength log")
+                            .font(.system(size: DesignTokens.Typography.Size.sm, weight: DesignTokens.Typography.Weight.regular, design: .monospaced))
+                            .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
+                    }
+                }
             }
             .frame(maxWidth: .infinity)
             Spacer()


### PR DESCRIPTION
## What

A small "Also from IAMJARL" caption + "Anvil Workout: strength log" link on the About sheet, under the existing Support / Privacy Policy links, in the same tertiary monospaced style. Links directly to Anvil's App Store page (`apps.apple.com/app/id6760627760`).

- iOS and macOS only. tvOS is skipped: no browser or App Store hand-off there.
- CHANGELOG gets an Unreleased section that also carries the reminder to apply the staged keyword expansion when this ships.

## Why

Pairing-sprint item 5a (see the private strategy repo): reciprocal, unobtrusive cross-promo between the two fitness siblings. Anvil mirrors this on its side.

## Verification

`xcodebuild build` passes for iOS Simulator and macOS destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)