### PR TITLE
ci: scan workflow files with CodeQL again (actions analysis job)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,23 @@ permissions:
   actions: read
 
 jobs:
+  # Scans the workflow files themselves (missing permissions, injection risks).
+  # Seconds-fast on ubuntu; no build needed. Replaces the old default-setup
+  # actions analysis so .github/workflows/ stays covered.
+  analyze-actions:
+    name: Actions workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+
   analyze:
     name: Swift
     runs-on: macos-latest


### PR DESCRIPTION
## What

Adds a lightweight `analyze-actions` job to the CodeQL workflow (`languages: actions`, ubuntu, seconds-fast, no build) so the workflow files themselves are scanned for missing permissions / injection risks again.

## Why

The Security tab showed "Code scanning configuration error" plus one stale open alert. Root cause: the repo switched from GitHub's default CodeQL setup to the advanced `codeql.yml` in May, carrying over only Swift. The default setup's four configurations (`/language:actions`, `python`, `ruby`, `swift`) were orphaned: the banner complained about them, and the actions alert on `docs.yml` (fixed long ago, the file has had `permissions: contents: read` since) could never auto-close because nothing re-analyzed that category.

Cleanup already done via the API (orphaned analyses deleted; open alerts now 0). This PR restores forward-looking coverage of `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)