### PR TITLE
Add Walkful to site footers and the in-app cross-promo list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to WODrounds. Newest first.
 ## Unreleased
 
 - **Added (iOS/macOS):** a discreet "Also from IAMJARL" line on the About screen linking to Anvil Workout on the App Store. Not on tvOS (no browser hand-off there).
+- **Added (iOS/macOS):** Walkful joined the same "Also from IAMJARL" list on the About screen.
 - Reminder for the next release: apply the expanded App Store keyword fields from `docs/APP_STORE_CONNECT.md` (staged 2026-07-11; keywords only update when a version ships).
 
 ## 1.5.1 (build 15)

--- a/WODrounds/iOSContentView.swift
+++ b/WODrounds/iOSContentView.swift
@@ -663,6 +663,13 @@ private struct AboutView: View {
                             .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
                     }
                 }
+                if let url = URL(string: "https://apps.apple.com/app/id6781303837") {
+                    Link(destination: url) {
+                        Text("Walkful: daily walking")
+                            .font(.system(size: DesignTokens.Typography.Size.sm, weight: DesignTokens.Typography.Weight.regular, design: .monospaced))
+                            .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
+                    }
+                }
             }
             .frame(maxWidth: .infinity)
             .padding(.horizontal)

--- a/WODrounds/macOSContentView.swift
+++ b/WODrounds/macOSContentView.swift
@@ -418,6 +418,13 @@ private struct MacAboutView: View {
                             .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
                     }
                 }
+                if let url = URL(string: "https://apps.apple.com/app/id6781303837") {
+                    Link(destination: url) {
+                        Text("Walkful: daily walking")
+                            .font(.system(size: DesignTokens.Typography.Size.sm, weight: DesignTokens.Typography.Weight.regular, design: .monospaced))
+                            .foregroundStyle(DesignTokens.Common.Text.tertiary(scheme))
+                    }
+                }
             }
             .frame(maxWidth: .infinity)
             Spacer()

--- a/docs/about.html
+++ b/docs/about.html
@@ -142,6 +142,7 @@
         <p>WODrounds is one of several small projects I work on. Each is single-purpose and free of accounts, ads, and tracking:</p>
         <ul>
           <li><a href="https://anvilworkout.iamjarl.com" rel="external">Anvil Workout</a>: a pay-once strength log for iPhone, iPad and Apple Watch. Log your lifting there, time your conditioning here.</li>
+          <li><a href="https://walkful.iamjarl.com" rel="external">Walkful</a>: a calm daily walking app for iPhone. Pay once, and your steps stay on your device.</li>
           <li><a href="https://weannicotine.iamjarl.com" rel="external">Wean Nicotine</a>: a structured nicotine reduction tool</li>
           <li><a href="https://madebyhuman.iamjarl.com" rel="external">Made by Human</a>: badges for content disclosing human vs. AI authorship</li>
           <li><a href="https://gettothemovie.iamjarl.com" rel="external">Get to the Movie!</a>: film timing planner</li>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -228,6 +228,7 @@
       <p class="footer-links" style="margin-top:0.5rem;font-size:0.85em;opacity:0.75;">More from IAMJARL</p>
       <p class="footer-links">
         <a href="https://anvilworkout.iamjarl.com">Anvil Workout</a>
+        <a href="https://walkful.iamjarl.com">Walkful</a>
         <a href="https://weannicotine.iamjarl.com">Wean Nicotine</a>
         <a href="https://gettothemovie.iamjarl.com">Get to the Movie!</a>
         <a href="https://trimrpix.iamjarl.com">TrimrPix</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -373,6 +373,7 @@
       <p class="footer-links" style="margin-top:0.5rem;font-size:0.85em;opacity:0.75;">More from IAMJARL</p>
       <p class="footer-links">
         <a href="https://anvilworkout.iamjarl.com">Anvil Workout</a>
+        <a href="https://walkful.iamjarl.com">Walkful</a>
         <a href="https://weannicotine.iamjarl.com">Wean Nicotine</a>
         <a href="https://gettothemovie.iamjarl.com">Get to the Movie!</a>
         <a href="https://trimrpix.iamjarl.com">TrimrPix</a>


### PR DESCRIPTION
## What

Trio-extension items 6a + 6b from the pairing sprint (private strategy repo):

1. **Site (6a):** Walkful added to the "More from IAMJARL" footer on the homepage and guide, and to the About page list with a promise-framed line ("a calm daily walking app for iPhone. Pay once, and your steps stay on your device") — deliberately not framed as fitness, per the trio doctrine (Walkful's anti-persona is the competitive athlete).
2. **In-app (6b):** "Walkful: daily walking" joins the About screen's "Also from IAMJARL" list on iOS + macOS, linking to its App Store page (`id6781303837`). Same tertiary style as the Anvil link; tvOS unchanged.

CHANGELOG's Unreleased section updated.

## Verification

`xcodebuild build` passes for iOS Simulator and macOS. `scripts/validate_docs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)