### PR TITLE
Watch standalone: configure EMOM and Intervals on the wrist (1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 All notable user-facing changes to WODrounds. Newest first.
 
-## Unreleased
+## 1.6 (build 16)
 
-- **Added (iOS/macOS):** a discreet "Also from IAMJARL" line on the About screen linking to Anvil Workout on the App Store. Not on tvOS (no browser hand-off there).
-- **Added (iOS/macOS):** Walkful joined the same "Also from IAMJARL" list on the About screen.
-- Reminder for the next release: apply the expanded App Store keyword fields from `docs/APP_STORE_CONNECT.md` (staged 2026-07-11; keywords only update when a version ships).
+**What's New (App Store copy):**
+
+> • Set up workouts directly on your Apple Watch: choose EMOM or Intervals and adjust rounds, round length, work and rest right on the wrist. No iPhone needed.
+> • The Watch remembers your settings between workouts.
+> • Small fixes and polish.
+
+**Details:**
+
+- **Added (watchOS):** standalone workout configuration (#32, #33). The Watch idle screen is now a setup screen: an EMOM/Intervals mode switch plus steppers for rounds and round length (EMOM) or work, rest and rounds (Intervals), same ranges as iOS. Values persist via `@AppStorage`; previously standalone was hardcoded to 10 × 1:00 EMOM. Synced (iPhone-driven) workouts are unchanged, and there is still no local For Time on the Watch.
+- **Added (iOS/macOS):** a discreet "Also from IAMJARL" section on the About screen linking Anvil Workout and Walkful on the App Store. Not on tvOS (no browser hand-off there).
+- **Release note:** the expanded App Store keyword fields from `docs/APP_STORE_CONNECT.md` (staged 2026-07-11) apply with this release.
 
 ## 1.5.1 (build 15)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ All public copy (App Store text, site copy, community posts, replies, release no
 - **For Time (new in 1.5):** counts up from zero; optional time cap (0:30–60:00, 30s steps; 0 = "No cap"). Uncapped runs until Stop; capped auto-finishes at the cap. Stop freezes the final time; Done screen shows "Finished in MM:SS". No rounds, no in-round cues. Watch follows a synced For Time (no local Watch For Time).
 - Start / Pause / Resume / Reset / Cancel; Done screen on completion. For Time uses Stop instead of Pause while running.
 - **iPhone → Watch sync** via WatchConnectivity (start on iPhone, follow on Watch).
+- **Watch standalone (new in 1.6):** the Watch configures and runs EMOM and Intervals on its own (mode switch + steppers, settings persisted via `@AppStorage`). For Time is still synced-only on the Watch.
 - **Date-based timing:** reliable when backgrounded; deterministic engine (`Shared/WODTimerEngine.swift`), no UI/sound in the engine.
 - Sound cues (count-in, halfway, 10s, 3-2-1, rounds-remaining), haptics (iOS), HealthKit save as HIIT (iOS only).
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Tabata (e.g. 20/10 × 8) is a manual Intervals preset.
 - Stop freezes your final time; the Done screen shows "Finished in MM:SS". No rounds, no in-round audio cues. Saves to Apple Health like the other modes.
 - Apple Watch follows a synced For Time workout (count-up on the wrist); there is no local For Time mode on the Watch.
 
+### Apple Watch standalone (new in 1.6)
+- The Watch configures and runs **EMOM and Intervals workouts on its own** — a mode switch plus steppers for rounds / round length (EMOM) or work / rest / rounds (Intervals), same ranges as iOS. Settings persist between workouts.
+- When a workout is started on iPhone, the Watch follows the synced state instead (unchanged).
+
 **In-app flow:** Choose EMOM, Intervals or For Time → set rounds (Intervals: work/rest; For Time: optional cap) → Start → timer runs → Pause/Resume (EMOM/Intervals), Stop (For Time) or Cancel → on completion, Done screen → Reset returns to setup.
 
 ---

--- a/WODrounds.xcodeproj/project.pbxproj
+++ b/WODrounds.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=appletvos*]" = "WODrounds/WODrounds-tvOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "WODrounds/WODrounds-Mac.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				ENABLE_APP_SANDBOX = YES;
@@ -587,7 +587,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
@@ -614,7 +614,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=appletvos*]" = "WODrounds/WODrounds-tvOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "WODrounds/WODrounds-Mac.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				ENABLE_APP_SANDBOX = YES;
@@ -642,7 +642,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
@@ -664,13 +664,13 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -690,13 +690,13 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -715,13 +715,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -740,13 +740,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODroundsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -768,14 +768,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WODroundsWatch/WODroundsWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "WODroundsWatch-Info.plist";
 				INFOPLIST_KEY_CFBundleIconName = AppIcon;
 				INFOPLIST_KEY_LSApplicationCategory = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.iamjarl.WODrounds;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -795,14 +795,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WODroundsWatch/WODroundsWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = KDWZ3WNLDK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "WODroundsWatch-Info.plist";
 				INFOPLIST_KEY_CFBundleIconName = AppIcon;
 				INFOPLIST_KEY_LSApplicationCategory = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.iamjarl.WODrounds;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iamjarl.WODrounds.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;

--- a/WODroundsWatch/WatchContentView.swift
+++ b/WODroundsWatch/WatchContentView.swift
@@ -8,9 +8,25 @@
 import SwiftUI
 import WatchKit
 
+// Local copies of the shared setup ranges (ContentView.swift is not a member
+// of the Watch target). Keep in sync with WODrounds/ContentView.swift.
+private let watchRoundsRange = 1 ... 120
+private let watchEmomLengthRange = 30 ... 570
+private let watchIntervalsWorkRange = 5 ... 300
+private let watchIntervalsRestRange = 0 ... 180
+private let watchIntervalsRoundsRange = 1 ... 60
+
 // MARK: - Watch Content View
 
 struct WatchContentView: View {
+    // Local (standalone) workout configuration, persisted between launches.
+    @AppStorage("watchTimerMode") private var storedMode: String = "emom"
+    @AppStorage("watchEmomRounds") private var emomRounds: Int = 10
+    @AppStorage("watchEmomLength") private var emomLength: Int = 60
+    @AppStorage("watchIntervalsWork") private var intervalsWork: Int = 30
+    @AppStorage("watchIntervalsRest") private var intervalsRest: Int = 15
+    @AppStorage("watchIntervalsRounds") private var intervalsRounds: Int = 8
+
     @State private var engine = WODTimerEngine(emomRounds: 10, secondsPerRound: 60)
     @State private var countdownEndTime: Date? = nil
     @Environment(\.colorScheme) private var colorScheme
@@ -19,6 +35,14 @@ struct WatchContentView: View {
     @StateObject private var sessionManager = WatchSessionManager.shared
     @StateObject private var workoutSession = WatchWorkoutSession.shared
     @State private var wasWorkoutActive = false
+
+    private func rebuildEngine() {
+        if storedMode == "intervals" {
+            engine = WODTimerEngine(workSeconds: intervalsWork, restSeconds: intervalsRest, rounds: intervalsRounds)
+        } else {
+            engine = WODTimerEngine(emomRounds: emomRounds, secondsPerRound: emomLength)
+        }
+    }
 
     private func timeString(from interval: TimeInterval) -> String {
         let totalSeconds = max(0, Int(ceil(interval)))
@@ -60,69 +84,64 @@ struct WatchContentView: View {
                 WatchDesign.Colors.background(colorScheme)
                     .ignoresSafeArea()
 
-                VStack(spacing: WatchDesign.Spacing.lg) {
-                    if useSynced {
-                        Text("iPhone", bundle: .main)
-                            .font(.system(size: WatchDesign.roundFontSize, weight: .medium, design: .rounded))
-                            .foregroundStyle(WatchDesign.Colors.textTertiary(colorScheme))
-                    }
+                if !useSynced && state == .idle {
+                    // Standalone setup: mode switch + steppers + Start (#32/#33).
+                    configView(now: now)
+                } else {
+                    VStack(spacing: WatchDesign.Spacing.lg) {
+                        if useSynced {
+                            Text("iPhone", bundle: .main)
+                                .font(.system(size: WatchDesign.roundFontSize, weight: .medium, design: .rounded))
+                                .foregroundStyle(WatchDesign.Colors.textTertiary(colorScheme))
+                        }
 
-                    // Count-up (For Time) floors so the shown time never runs ahead;
-                    // count-down keeps ceiling so 0 is only shown when truly done.
-                    Text(timeString(from: isSyncedForTime ? floor(displayTime) : displayTime))
-                        .font(.system(size: WatchDesign.timerFontSize, weight: .bold, design: .rounded))
-                        .monospacedDigit()
-                        .foregroundStyle(WatchDesign.Colors.textPrimary(colorScheme))
+                        // Count-up (For Time) floors so the shown time never runs ahead;
+                        // count-down keeps ceiling so 0 is only shown when truly done.
+                        Text(timeString(from: isSyncedForTime ? floor(displayTime) : displayTime))
+                            .font(.system(size: WatchDesign.timerFontSize, weight: .bold, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundStyle(WatchDesign.Colors.textPrimary(colorScheme))
 
-                    if !isSyncedForTime {
-                        Text("R \(currentRound)/\(totalRounds)")
-                            .font(.system(size: WatchDesign.roundFontSize, weight: .semibold, design: .rounded))
-                            .foregroundStyle(WatchDesign.Colors.textSecondary(colorScheme))
-                    }
+                        if !isSyncedForTime {
+                            Text("R \(currentRound)/\(totalRounds)")
+                                .font(.system(size: WatchDesign.roundFontSize, weight: .semibold, design: .rounded))
+                                .foregroundStyle(WatchDesign.Colors.textSecondary(colorScheme))
+                        }
 
-                    if useSynced {
-                        Text("Following iPhone", bundle: .main)
-                            .font(.system(size: 10, weight: .regular, design: .rounded))
-                            .foregroundStyle(WatchDesign.Colors.textTertiary(colorScheme))
-                    } else {
-                        HStack(spacing: WatchDesign.Spacing.sm) {
-                            switch state {
-                            case .idle:
-                                Button("Start") {
-                                    countdownEndTime = now.addingTimeInterval(10)
-                                    // Bug fix: start HKWorkoutSession immediately on Start so the
-                                    // app stays alive during the 10s countdown (previously the
-                                    // session only started when engine.state became .running,
-                                    // leaving a window where the Watch could be suspended).
-                                    workoutSession.startIfNeeded()
+                        if useSynced {
+                            Text("Following iPhone", bundle: .main)
+                                .font(.system(size: 10, weight: .regular, design: .rounded))
+                                .foregroundStyle(WatchDesign.Colors.textTertiary(colorScheme))
+                        } else {
+                            HStack(spacing: WatchDesign.Spacing.sm) {
+                                switch state {
+                                case .idle:
+                                    EmptyView() // idle renders configView above
+                                case .running:
+                                    Button("Pause") {
+                                        engine.pause(now: now)
+                                    }
+                                    .buttonStyle(.borderedProminent)
+                                    .tint(WatchDesign.Colors.primary(colorScheme))
+                                    .foregroundStyle(WatchDesign.Colors.onPrimary)
+                                case .paused:
+                                    Button("Resume") {
+                                        engine.resume(now: now)
+                                    }
+                                    .buttonStyle(.borderedProminent)
+                                    .tint(WatchDesign.Colors.primary(colorScheme))
+                                    .foregroundStyle(WatchDesign.Colors.onPrimary)
+                                case .finished:
+                                    Button("Reset") {
+                                        engine.reset()
+                                    }
+                                    .buttonStyle(.bordered)
                                 }
-                                .buttonStyle(.borderedProminent)
-                                .tint(WatchDesign.Colors.primary(colorScheme))
-                                .foregroundStyle(WatchDesign.Colors.onPrimary)
-                            case .running:
-                                Button("Pause") {
-                                    engine.pause(now: now)
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .tint(WatchDesign.Colors.primary(colorScheme))
-                                .foregroundStyle(WatchDesign.Colors.onPrimary)
-                            case .paused:
-                                Button("Resume") {
-                                    engine.resume(now: now)
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .tint(WatchDesign.Colors.primary(colorScheme))
-                                .foregroundStyle(WatchDesign.Colors.onPrimary)
-                            case .finished:
-                                Button("Reset") {
-                                    engine.reset()
-                                }
-                                .buttonStyle(.bordered)
                             }
                         }
                     }
+                    .padding(WatchDesign.Spacing.md)
                 }
-                .padding(WatchDesign.Spacing.md)
 
                 // Full-screen flash overlay (placed at ZStack level so it covers the entire
                 // screen — previously it was attached to the padded VStack and only covered
@@ -198,6 +217,104 @@ struct WatchContentView: View {
                     workoutSession.stop()
                 }
             }
+            .onAppear {
+                rebuildEngine()
+            }
+        }
+    }
+
+    // MARK: - Standalone setup (#32 / #33)
+
+    private func lengthString(_ seconds: Int) -> String {
+        String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
+
+    private func configView(now: Date) -> some View {
+        ScrollView {
+            VStack(spacing: WatchDesign.Spacing.md) {
+                // Mode switch
+                HStack(spacing: WatchDesign.Spacing.sm) {
+                    modeButton("EMOM", mode: "emom")
+                    modeButton("Intervals", mode: "intervals")
+                }
+
+                if storedMode == "intervals" {
+                    configRow("WORK", value: lengthString(intervalsWork),
+                              range: watchIntervalsWorkRange, step: 5, binding: $intervalsWork)
+                    configRow("REST", value: lengthString(intervalsRest),
+                              range: watchIntervalsRestRange, step: 5, binding: $intervalsRest)
+                    configRow("ROUNDS", value: "\(intervalsRounds)",
+                              range: watchIntervalsRoundsRange, step: 1, binding: $intervalsRounds)
+                } else {
+                    configRow("ROUNDS", value: "\(emomRounds)",
+                              range: watchRoundsRange, step: 1, binding: $emomRounds)
+                    configRow("LENGTH", value: lengthString(emomLength),
+                              range: watchEmomLengthRange, step: 30, binding: $emomLength)
+                }
+
+                Button("Start") {
+                    rebuildEngine()
+                    countdownEndTime = now.addingTimeInterval(10)
+                    // Start the HKWorkoutSession immediately so the app stays
+                    // alive during the 10s countdown (same fix as before).
+                    workoutSession.startIfNeeded()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(WatchDesign.Colors.primary(colorScheme))
+                .foregroundStyle(WatchDesign.Colors.onPrimary)
+                .padding(.top, WatchDesign.Spacing.xs)
+            }
+            .padding(.horizontal, WatchDesign.Spacing.md)
+            .padding(.vertical, WatchDesign.Spacing.sm)
+        }
+    }
+
+    private func modeButton(_ title: LocalizedStringKey, mode: String) -> some View {
+        let isActive = storedMode == mode
+        return Button(title) {
+            storedMode = mode
+            rebuildEngine()
+        }
+        .font(.system(size: 11, weight: isActive ? .semibold : .regular, design: .rounded))
+        .buttonStyle(.bordered)
+        .tint(isActive ? WatchDesign.Colors.primary(colorScheme) : nil)
+        .foregroundStyle(isActive
+                         ? WatchDesign.Colors.textPrimary(colorScheme)
+                         : WatchDesign.Colors.textSecondary(colorScheme))
+    }
+
+    private func configRow(_ label: LocalizedStringKey, value: String,
+                           range: ClosedRange<Int>, step: Int,
+                           binding: Binding<Int>) -> some View {
+        HStack(spacing: WatchDesign.Spacing.sm) {
+            Button {
+                binding.wrappedValue = max(range.lowerBound, binding.wrappedValue - step)
+                rebuildEngine()
+            } label: {
+                Image(systemName: "minus")
+            }
+            .buttonStyle(.bordered)
+            .disabled(binding.wrappedValue <= range.lowerBound)
+
+            VStack(spacing: 0) {
+                Text(label)
+                    .font(.system(size: 9, weight: .medium, design: .rounded))
+                    .foregroundStyle(WatchDesign.Colors.textTertiary(colorScheme))
+                Text(value)
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(WatchDesign.Colors.textPrimary(colorScheme))
+            }
+            .frame(maxWidth: .infinity)
+
+            Button {
+                binding.wrappedValue = min(range.upperBound, binding.wrappedValue + step)
+                rebuildEngine()
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.bordered)
+            .disabled(binding.wrappedValue >= range.upperBound)
         }
     }
 

--- a/docs/APP_STORE_CONNECT.md
+++ b/docs/APP_STORE_CONNECT.md
@@ -54,26 +54,27 @@ The simplest WOD timer: no database, no sharing. Just timer and rounds.
 
 ## What's New in This Version (release notes)
 
-Update per release. Current — **1.5.1** (iOS):
+Update per release. Current — **1.6** (iOS):
 
 ```
-• Fixed the info button overlapping the For Time tab on iPhone.
-• Tidied up the About screen so the Support and Privacy Policy links sit where they should.
+• Set up workouts directly on your Apple Watch: choose EMOM or Intervals and adjust rounds, round length, work and rest right on the wrist. No iPhone needed.
+• The Watch remembers your settings between workouts.
 • Small fixes and polish.
 ```
 
-**Mac / tvOS variant (1.5.1)** — the info-icon overlap was iOS-only, so only the About fix applies. Do not mention the For Time tab here:
+**Mac / tvOS variant (1.6)** — the Watch feature ships with the iOS listing only; keep Mac/tvOS generic:
 
 ```
-• Tidied up the About screen so the Support and Privacy Policy links sit where they should.
 • Small fixes and polish.
 ```
+
+**Remember with this release:** apply the expanded keyword fields (marked "Apply with the next release" in the Keywords sections below) for iOS and Mac.
 
 Promotional Text is unchanged from 1.5 (not version-specific): see the per-platform Promotional Text sections above.
 
-<details><summary>Previous — 1.5 What's New (for reference)</summary>
+<details><summary>Previous — 1.5.1 What's New (for reference)</summary>
 
-iOS: "New: For Time mode. The clock counts up from zero; press Stop when you finish and your time is saved. · Set an optional time cap and the For Time clock stops there automatically. · Your Apple Watch follows a For Time workout when you start on iPhone. · Small fixes and polish." Mac/tvOS dropped the Watch line.
+iOS: "Fixed the info button overlapping the For Time tab on iPhone. · Tidied up the About screen so the Support and Privacy Policy links sit where they should. · Small fixes and polish." Mac/tvOS dropped the info-button line.
 
 </details>
 
@@ -292,17 +293,17 @@ Single words, comma-separated, no spaces; excludes terms already in the subtitle
 intervalos,entrenamiento,EMOM,CrossFit,gimnasio,cronómetro,cuenta,regresiva,WOD,rondas,ejercicio
 ```
 
-## What's New in This Version (1.5.1) — es-MX
+## What's New in This Version (1.6) — es-MX
 
 ```
-• Se corrigió el botón de información que se superponía a la pestaña For Time en el iPhone.
-• Se ordenó la pantalla Acerca de para que los enlaces de Soporte y Política de privacidad queden en su lugar.
+• Configura tus entrenamientos directamente en el Apple Watch: elige EMOM o Intervalos y ajusta rondas, duración, trabajo y descanso desde la muñeca. Sin necesidad del iPhone.
+• El Watch recuerda tu configuración entre entrenamientos.
 • Pequeñas correcciones y mejoras.
 ```
 
-<details><summary>Anterior — 1.5 (referencia)</summary>
+<details><summary>Anterior — 1.5.1 (referencia)</summary>
 
-"Nuevo: modo For Time. El reloj cuenta desde cero; pulsa Detener al terminar y tu tiempo queda guardado. · Define un límite de tiempo opcional y el reloj se detiene ahí automáticamente. · Tu Apple Watch sigue el entrenamiento For Time cuando empiezas en el iPhone. · Pequeñas correcciones y mejoras."
+"Se corrigió el botón de información que se superponía a la pestaña For Time en el iPhone. · Se ordenó la pantalla Acerca de para que los enlaces de Soporte y Política de privacidad queden en su lugar. · Pequeñas correcciones y mejoras."
 
 </details>
 


### PR DESCRIPTION
## What

Closes #32 and closes #33 — the two Watch standalone issues, done together as the 1.6 feature.

The Watch idle screen is now a setup screen:
- **Mode switch** (EMOM / Intervals), persisted via `@AppStorage("watchTimerMode")`.
- **EMOM:** steppers for rounds (1–120) and round length (0:30–9:30, 30s steps).
- **Intervals:** steppers for work (5s steps), rest, and rounds — same ranges as iOS.
- Values persist between workouts; the engine is rebuilt on every change and on appear.
- Compact +/- rows in a ScrollView (chosen over Digital Crown focus juggling, per #32's UX note).

Synced (iPhone-driven) workouts and the running/paused/finished UI are unchanged. For Time stays synced-only on the Watch.

## Release prep (1.6, build 16)

- `MARKETING_VERSION` 1.6, `CURRENT_PROJECT_VERSION` 16 (all configurations).
- CHANGELOG entry with App Store What's New copy; `docs/APP_STORE_CONNECT.md` updated (EN + es-MX What's New, Mac/tvOS variant, reminder to apply the staged expanded keyword fields with this release).
- README + CLAUDE.md feature lists updated (Watch standalone section; hallucination guards intact).

## Verification

- watchOS target builds; ran in the Apple Watch Series 11 simulator: EMOM config renders (mode switch + ROUNDS/LENGTH rows + Start), Intervals config renders (WORK/REST/ROUNDS + Start, ScrollView scrolls), mode switch toggles by tap, launch-argument defaults honored.
- Engine paths are the existing unit-tested inits; the countdown/start flow is unchanged code.
- `scripts/validate_docs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)