### PR TITLE
Fix tvOS onChange deprecation warnings

### DIFF
--- a/WODrounds/tvOSContentView.swift
+++ b/WODrounds/tvOSContentView.swift
@@ -87,7 +87,7 @@ struct ContentView: View {
     var body: some View {
         TimelineView(.periodic(from: Date(), by: 1.0)) { timeline in
             tvOSContent(now: timeline.date, rounds: $rounds, emomRoundLength: $emomRoundLengthSeconds, intervalsWork: $intervalsWork, intervalsRest: $intervalsRest, intervalsRounds: $intervalsRounds)
-                .onChange(of: timeline.date) { newDate in
+                .onChange(of: timeline.date) { _, newDate in
                     if engine.state == .running {
                         var e = engine
                         e.tick(now: newDate)
@@ -103,14 +103,14 @@ struct ContentView: View {
                     }
                     checkInRoundCues(now: newDate)
                 }
-                .onChange(of: engine.snapshot(now: timeline.date).currentRound) { newRound in
+                .onChange(of: engine.snapshot(now: timeline.date).currentRound) { _, newRound in
                     if (engine.state == .running || engine.state == .paused), timerMode == .emom, newRound > lastHapticRound {
                         triggerFlash()
                         lastHapticRound = newRound
                         WorkoutSoundManager.checkRoundsRemaining(currentRound: newRound, totalRounds: rounds)
                     }
                 }
-                .onChange(of: engine.snapshot(now: timeline.date).currentPhase) { newPhase in
+                .onChange(of: engine.snapshot(now: timeline.date).currentPhase) { _, newPhase in
                     if (engine.state == .running || engine.state == .paused), timerMode == .intervals, newPhase != lastHapticPhase {
                         triggerFlash()
                         lastHapticPhase = newPhase
@@ -123,7 +123,7 @@ struct ContentView: View {
                         }
                     }
                 }
-                .onChange(of: engine.state) { newState in
+                .onChange(of: engine.state) { _, newState in
                     if newState == .finished {
                         WorkoutSoundManager.playYouDidIt()
                     }


### PR DESCRIPTION
## What

Migrates the four `onChange(of:perform:)` modifiers in `tvOSContentView.swift` to the two-parameter closure form, silencing the four deprecation warnings that showed up in the Xcode Cloud tvOS archive.

## Why only tvOS

The deprecation applies from OS 17, and tvOS is the only platform in the project with a minimum that high (17.0). iOS (16.0), macOS (13.0) and watchOS (9.0) deliberately keep the old form since the replacement API doesn't exist on their minimum versions.

No behavior change. tvOS builds clean with zero deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)