### PR TITLE
docs: macOS 1.6 App Store copy voice-audit fix

### DIFF
--- a/docs/APP_STORE_CONNECT.md
+++ b/docs/APP_STORE_CONNECT.md
@@ -202,7 +202,7 @@ Interval timer and workout timer for EMOM, For Time, CrossFit, and HIIT on Mac. 
 • Compact window, large type. Runs in background. Light and dark theme.
 • One-time purchase: pay once, own it forever. No subscription, no ads, no in-app purchases.
 
-The same minimal WOD timer as on iPhone and Apple Watch – no database, no sharing. Just timer and rounds.
+The same minimal WOD timer as on iPhone and Apple Watch. No database, no sharing. Just timer and rounds.
 ```
 
 ## Keywords (max 100 characters)


### PR DESCRIPTION
Removes the en-dash from the Mac description's closing line (VOICE: no em-dashes). Mac copy is otherwise voice-clean. What's New stays "Small fixes and polish" since the 1.6 Watch-standalone feature is iOS-only; the expanded Mac keyword field is already staged.

Docs-only; `scripts/validate_docs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)