### PR TITLE
docs: tvOS 1.6 App Store copy voice-audit fix

### DIFF
--- a/docs/APP_STORE_CONNECT.md
+++ b/docs/APP_STORE_CONNECT.md
@@ -248,7 +248,7 @@ Interval timer and workout timer for EMOM, For Time, CrossFit, and HIIT on Apple
 • Large type for the living room. Focus-friendly UI. Light and dark theme.
 • One-time purchase: pay once, own it forever. No subscription, no ads, no in-app purchases.
 
-The same minimal WOD timer as on iPhone, Watch, and Mac – no database, no sharing. Just timer and rounds.
+The same minimal WOD timer as on iPhone, Watch, and Mac. No database, no sharing. Just timer and rounds.
 ```
 
 ## Keywords (max 100 characters)


### PR DESCRIPTION
Removes the en-dash from the Apple TV description's closing line (VOICE: no em-dashes). tvOS copy is otherwise voice-clean. What's New stays "Small fixes and polish" (the 1.6 Watch-standalone feature is iOS-only); keywords are unchanged (~87 chars). This completes the App Store voice sweep across iOS, Mac and tvOS for 1.6.

Docs-only; `scripts/validate_docs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)