### PR TITLE
site: Umami honors Do Not Track + fix Sentry disclosure on About

### DIFF
--- a/docs/10-minute-hiit-workout.html
+++ b/docs/10-minute-hiit-workout.html
@@ -61,7 +61,7 @@
     "dateModified": "2026-04-15"
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/20-minute-hiit-workout.html
+++ b/docs/20-minute-hiit-workout.html
@@ -61,7 +61,7 @@
     "dateModified": "2026-04-15"
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/about.html
+++ b/docs/about.html
@@ -74,7 +74,7 @@
     }
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">
@@ -123,7 +123,7 @@
         </ul>
 
         <h2>Privacy as a feature, not a clause</h2>
-        <p>WODrounds doesn't have a backend. There's no server collecting your workout data. No accounts to compromise. No tracking pixels. The full <a href="privacy.html">Privacy Policy</a> covers the small honest exceptions: optional iOS crash reporting via Sentry (opt-in), HealthKit write-only integration (if you enable it), and aggregate page-view stats for this website via Umami (no cookies, no fingerprinting).</p>
+        <p>WODrounds doesn't have a backend. There's no server collecting your workout data. No accounts to compromise. No tracking pixels. The full <a href="privacy.html">Privacy Policy</a> covers the small honest exceptions: automatic iOS crash reporting via Sentry (device type, OS and app state, never your workout or identity), HealthKit write-only integration (if you enable it), and aggregate page-view stats for this website via Umami (no cookies, no fingerprinting).</p>
         <p>If you want to verify any of this, the source is open at <a href="https://github.com/JarlLyng/WODrounds" rel="external">github.com/JarlLyng/WODrounds</a>.</p>
 
         <h2>What I do and don't promise</h2>

--- a/docs/apple-watch-timer.html
+++ b/docs/apple-watch-timer.html
@@ -100,7 +100,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/beginner-hiit-workout.html
+++ b/docs/beginner-hiit-workout.html
@@ -61,7 +61,7 @@
     "dateModified": "2026-04-15"
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/best-crossfit-timer-apps.html
+++ b/docs/best-crossfit-timer-apps.html
@@ -60,7 +60,7 @@
     "dateModified": "2026-04-22"
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/da/apple-watch-timer.html
+++ b/docs/da/apple-watch-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/da/emom-timer.html
+++ b/docs/da/emom-timer.html
@@ -64,7 +64,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/da/for-time-timer.html
+++ b/docs/da/for-time-timer.html
@@ -95,7 +95,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/da/index.html
+++ b/docs/da/index.html
@@ -53,7 +53,7 @@
     }
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/da/interval-timer.html
+++ b/docs/da/interval-timer.html
@@ -65,7 +65,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/da/tabata-timer.html
+++ b/docs/da/tabata-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/de/apple-watch-timer.html
+++ b/docs/de/apple-watch-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/de/emom-timer.html
+++ b/docs/de/emom-timer.html
@@ -64,7 +64,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/de/for-time-timer.html
+++ b/docs/de/for-time-timer.html
@@ -95,7 +95,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -53,7 +53,7 @@
     }
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/de/interval-timer.html
+++ b/docs/de/interval-timer.html
@@ -65,7 +65,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/de/tabata-timer.html
+++ b/docs/de/tabata-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/emom-timer.html
+++ b/docs/emom-timer.html
@@ -102,7 +102,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/emom-workout-examples.html
+++ b/docs/emom-workout-examples.html
@@ -61,7 +61,7 @@
     "dateModified": "2026-04-15"
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/es/apple-watch-timer.html
+++ b/docs/es/apple-watch-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/es/emom-timer.html
+++ b/docs/es/emom-timer.html
@@ -64,7 +64,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/es/for-time-timer.html
+++ b/docs/es/for-time-timer.html
@@ -95,7 +95,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/es/index.html
+++ b/docs/es/index.html
@@ -53,7 +53,7 @@
     }
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/es/interval-timer.html
+++ b/docs/es/interval-timer.html
@@ -65,7 +65,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/es/tabata-timer.html
+++ b/docs/es/tabata-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/for-time-timer.html
+++ b/docs/for-time-timer.html
@@ -95,7 +95,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/fr/apple-watch-timer.html
+++ b/docs/fr/apple-watch-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/fr/emom-timer.html
+++ b/docs/fr/emom-timer.html
@@ -64,7 +64,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/fr/for-time-timer.html
+++ b/docs/fr/for-time-timer.html
@@ -95,7 +95,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -53,7 +53,7 @@
     }
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/fr/interval-timer.html
+++ b/docs/fr/interval-timer.html
@@ -65,7 +65,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/fr/tabata-timer.html
+++ b/docs/fr/tabata-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -75,7 +75,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/home-gym-hiit-workout.html
+++ b/docs/home-gym-hiit-workout.html
@@ -61,7 +61,7 @@
     "dateModified": "2026-04-15"
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/index.html
+++ b/docs/index.html
@@ -143,7 +143,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/interval-timer.html
+++ b/docs/interval-timer.html
@@ -95,7 +95,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/no/apple-watch-timer.html
+++ b/docs/no/apple-watch-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/no/emom-timer.html
+++ b/docs/no/emom-timer.html
@@ -64,7 +64,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/no/for-time-timer.html
+++ b/docs/no/for-time-timer.html
@@ -95,7 +95,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/no/index.html
+++ b/docs/no/index.html
@@ -53,7 +53,7 @@
     }
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/no/interval-timer.html
+++ b/docs/no/interval-timer.html
@@ -65,7 +65,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/no/tabata-timer.html
+++ b/docs/no/tabata-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -40,7 +40,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/support.html
+++ b/docs/support.html
@@ -40,7 +40,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/sv/apple-watch-timer.html
+++ b/docs/sv/apple-watch-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/sv/emom-timer.html
+++ b/docs/sv/emom-timer.html
@@ -64,7 +64,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/sv/for-time-timer.html
+++ b/docs/sv/for-time-timer.html
@@ -95,7 +95,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/sv/index.html
+++ b/docs/sv/index.html
@@ -53,7 +53,7 @@
     }
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/sv/interval-timer.html
+++ b/docs/sv/interval-timer.html
@@ -65,7 +65,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/sv/tabata-timer.html
+++ b/docs/sv/tabata-timer.html
@@ -49,7 +49,7 @@
     ]
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/tabata-timer.html
+++ b/docs/tabata-timer.html
@@ -103,7 +103,7 @@
   }
   </script>
 
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/tabata-workout-examples.html
+++ b/docs/tabata-workout-examples.html
@@ -61,7 +61,7 @@
     "dateModified": "2026-04-15"
   }
   </script>
-  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3"></script>
+  <script defer src="https://umami-iamjarl.vercel.app/script.js" data-website-id="7a65d61a-b231-4611-b514-3c6cd0a5b7b3" data-do-not-track="true" data-domains="wodrounds.iamjarl.com"></script>
 </head>
 <body>
   <header class="site-header">


### PR DESCRIPTION
Two privacy-consistency fixes on the marketing site.

- **Umami honors Do Not Track.** Adds `data-do-not-track="true"` (and `data-domains="wodrounds.iamjarl.com"`) to the Umami script on all 53 pages. Umami is cookieless regardless; by default it does not respect the browser DNT signal unless asked, so this makes it skip visitors who opted out, consistent with the privacy-first brand.
- **Fix the Sentry disclosure on About.** The About page called crash reporting "(opt-in)", but the app reports automatically (there is no opt-in toggle) and the Privacy Policy says so. Reworded to match reality: automatic, device type / OS / app state only, never workout or identity.

Docs/site only; `scripts/validate_docs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)