### PR TITLE
Sentry: privacy-minimal config (no screenshot, no prod tracing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable user-facing changes to WODrounds. Newest first.
 
+## Unreleased
+
+- **Changed (iOS, privacy):** crash reporting no longer attaches a screenshot, and performance tracing is off in production. Crash diagnostics now stay device type / OS / app state only, matching what the Privacy Policy describes (never your workout or identity).
+
 ## 1.6 (build 16)
 
 **What's New (App Store copy):**

--- a/WODrounds/WODroundsApp.swift
+++ b/WODrounds/WODroundsApp.swift
@@ -52,10 +52,17 @@ struct WODroundsApp: App {
             options.debug = true
             options.tracesSampleRate = 1.0
             #else
-            options.tracesSampleRate = 0.2
+            // Crash reports and release health only. No performance tracing in
+            // production: it sends transaction/timing data for a share of every
+            // session, which a minimal timer doesn't need and which goes beyond
+            // the "crash reports" the privacy policy describes.
+            options.tracesSampleRate = 0.0
             #endif
             options.enableAutoSessionTracking = true
-            options.attachScreenshot = true
+            // No crash screenshots. A crash on the timer screen would capture the
+            // user's workout (rounds, times), and the privacy policy states we do
+            // not send workout programming. Keep that promise true in code.
+            options.attachScreenshot = false
             options.enableMetricKit = true
         }
         #if DEBUG


### PR DESCRIPTION
Aligns the Sentry crash-reporting config with the Privacy Policy's promise that reports never include workout programming or identity.

- **`attachScreenshot = false`** — a crash on the timer screen would otherwise attach a screenshot showing the user's workout (rounds, times). The Privacy Policy explicitly says we do not send workout programming, so the screenshot has to go.
- **`tracesSampleRate = 0.0` in production** (was `0.2`) — performance tracing sends transaction/timing data for a share of every session, which goes beyond the "crash reports" the policy describes and adds little for a minimal timer. Debug keeps `1.0` for local diagnostics.

Session tracking and MetricKit stay on (low-sensitivity, useful for crash-free rate). No user-facing behavior change beyond less data leaving the device.

Ships with the next release (alongside the queued Description/keyword metadata fix). iOS build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)